### PR TITLE
Add context to serve

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -106,7 +106,7 @@ outer:
 		}
 
 		s.sessions.addListener(session)
-		_, err = session.Serve()
+		_, err = session.Serve(context.Background())
 		s.sessions.removeListener(session)
 		session.Close()
 

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package remotedialer
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"time"
@@ -71,7 +72,7 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	defer s.sessions.remove(session)
 
 	// Don't need to associate req.Context() to the Session, it will cancel otherwise
-	code, err := session.Serve()
+	code, err := session.Serve(context.Background())
 	if err != nil {
 		// Hijacked so we can't write to the client
 		logrus.Infof("error in remotedialer server [%d]: %v", code, err)

--- a/session.go
+++ b/session.go
@@ -63,8 +63,8 @@ func newSession(sessionKey int64, clientKey string, conn *websocket.Conn) *Sessi
 	}
 }
 
-func (s *Session) startPings() {
-	ctx, cancel := context.WithCancel(context.Background())
+func (s *Session) startPings(rootCtx context.Context) {
+	ctx, cancel := context.WithCancel(rootCtx)
 	s.pingCancel = cancel
 	s.pingWait.Add(1)
 
@@ -99,9 +99,9 @@ func (s *Session) stopPings() {
 	s.pingWait.Wait()
 }
 
-func (s *Session) Serve() (int, error) {
+func (s *Session) Serve(ctx context.Context) (int, error) {
 	if s.client {
-		s.startPings()
+		s.startPings(ctx)
 	}
 
 	for {


### PR DESCRIPTION
Add a context to `Serve` for `startPings` to use,
otherwise ping may be caught in a loop of trying
to use an already closed socket.