### PR TITLE
Run onConnect handler in the background

### DIFF
--- a/types.go
+++ b/types.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	PingWaitDuration  = time.Duration(10 * time.Second)
+	PingWaitDuration  = time.Duration(60 * time.Second)
 	PingWriteInterval = time.Duration(5 * time.Second)
 	MaxRead           = 8192
 )


### PR DESCRIPTION
Before if the onConnect handler ran longer than the ping wait duration then
the server would disconnect the client.  Now we run the onConnect handler in
the background to ensure that pings start sending right away.