### PR TITLE
Set read deadline on write

### DIFF
--- a/session.go
+++ b/session.go
@@ -80,7 +80,7 @@ func (s *Session) startPings(rootCtx context.Context) {
 				return
 			case <-t.C:
 				s.conn.Lock()
-				if err := s.conn.conn.WriteControl(websocket.PingMessage, []byte(""), time.Now().Add(time.Second)); err != nil {
+				if err := s.conn.conn.WriteControl(websocket.PingMessage, []byte(""), time.Now().Add(PingWaitDuration)); err != nil {
 					logrus.WithError(err).Error("Error writing ping")
 				}
 				logrus.Debug("Wrote ping")

--- a/wsconn.go
+++ b/wsconn.go
@@ -24,7 +24,9 @@ func newWSConn(conn *websocket.Conn) *wsConn {
 func (w *wsConn) WriteMessage(messageType int, data []byte) error {
 	w.Lock()
 	defer w.Unlock()
-	w.conn.SetWriteDeadline(time.Now().Add(PingWaitDuration))
+	t := time.Now().Add(PingWaitDuration)
+	w.conn.SetWriteDeadline(t)
+	w.conn.SetReadDeadline(t)
 	return w.conn.WriteMessage(messageType, data)
 }
 
@@ -36,7 +38,7 @@ func (w *wsConn) setupDeadline() {
 	w.conn.SetReadDeadline(time.Now().Add(PingWaitDuration))
 	w.conn.SetPingHandler(func(string) error {
 		w.Lock()
-		w.conn.WriteControl(websocket.PongMessage, []byte(""), time.Now().Add(time.Second))
+		w.conn.WriteControl(websocket.PongMessage, []byte(""), time.Now().Add(PingWaitDuration))
 		w.Unlock()
 		return w.conn.SetReadDeadline(time.Now().Add(PingWaitDuration))
 	})


### PR DESCRIPTION
It is possible that writes can starve the ping pong process because
a pong requires a write. In that situation the read deadline could
not be set. This patch we ensure we update the read deadline on
writes to keep the socket open when we are doing heavy writes.