### PR TITLE
Export ConnectToProxy() for some backoff stage

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,11 +10,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// ConnectAuthorizer custom for authorization
 type ConnectAuthorizer func(proto, address string) bool
 
+// ClientConnect connect to WS and wait 5 seconds when error
 func ClientConnect(ctx context.Context, wsURL string, headers http.Header, dialer *websocket.Dialer,
 	auth ConnectAuthorizer, onConnect func(context.Context) error) error {
-	if err := connectToProxy(ctx, wsURL, headers, auth, dialer, onConnect); err != nil {
+	if err := ConnectToProxy(ctx, wsURL, headers, auth, dialer, onConnect); err != nil {
 		logrus.WithError(err).Error("Remotedialer proxy error")
 		time.Sleep(time.Duration(5) * time.Second)
 		return err
@@ -22,7 +24,8 @@ func ClientConnect(ctx context.Context, wsURL string, headers http.Header, diale
 	return nil
 }
 
-func connectToProxy(rootCtx context.Context, proxyURL string, headers http.Header, auth ConnectAuthorizer, dialer *websocket.Dialer, onConnect func(context.Context) error) error {
+// ConnectToProxy connect to websocket server
+func ConnectToProxy(rootCtx context.Context, proxyURL string, headers http.Header, auth ConnectAuthorizer, dialer *websocket.Dialer, onConnect func(context.Context) error) error {
 	logrus.WithField("url", proxyURL).Info("Connecting to proxy")
 
 	if dialer == nil {

--- a/client.go
+++ b/client.go
@@ -12,18 +12,21 @@ import (
 
 type ConnectAuthorizer func(proto, address string) bool
 
-func ClientConnect(ctx context.Context, wsURL string, headers http.Header, dialer *websocket.Dialer, auth ConnectAuthorizer, onConnect func(context.Context) error) {
+func ClientConnect(ctx context.Context, wsURL string, headers http.Header, dialer *websocket.Dialer,
+	auth ConnectAuthorizer, onConnect func(context.Context) error) error {
 	if err := connectToProxy(ctx, wsURL, headers, auth, dialer, onConnect); err != nil {
 		logrus.WithError(err).Error("Remotedialer proxy error")
 		time.Sleep(time.Duration(5) * time.Second)
+		return err
 	}
+	return nil
 }
 
 func connectToProxy(rootCtx context.Context, proxyURL string, headers http.Header, auth ConnectAuthorizer, dialer *websocket.Dialer, onConnect func(context.Context) error) error {
 	logrus.WithField("url", proxyURL).Info("Connecting to proxy")
 
 	if dialer == nil {
-		dialer = &websocket.Dialer{Proxy:http.ProxyFromEnvironment,HandshakeTimeout:HandshakeTimeOut}
+		dialer = &websocket.Dialer{Proxy: http.ProxyFromEnvironment, HandshakeTimeout: HandshakeTimeOut}
 	}
 	ws, resp, err := dialer.Dial(proxyURL, headers)
 	if err != nil {


### PR DESCRIPTION
* Export ConnectToProxy() can support backoff for keepalive, like github.com/cenkalti/backoff, code example:
```go
import "time"
import "github.com/cenkalti/backoff"

func expBackoff() backoff.BackOff {
	b := backoff.NewExponentialBackOff()
	b.InitialInterval = 500 * time.Millisecond
	b.Multiplier = 1.5
	b.MaxInterval = 60 * time.Second
	b.MaxElapsedTime = 0 // never stop

	return b
}

// Retry ...
func Retry(o backoff.Operation) error {
	return backoff.RetryNotify(o, expBackoff(), func(err error, d time.Duration) {
		log.Print("retry", "err", err, "d", d)
	})
}

main() {
	Retry(func() error {
		return remotedialer.ConnectToProxy(context.Background(), uri, headers, 
			func(string, string) bool { return true }, nil, nil)
	})
}

```

* Add some comments