### PR TITLE
Add method to expose register metrics

### DIFF
--- a/metrics/session_manager.go
+++ b/metrics/session_manager.go
@@ -98,20 +98,26 @@ var (
 	)
 )
 
+// Register registers a series of session
+// metrics for Prometheus.
+func Register() {
+	// Session metrics
+	prometheus.MustRegister(TotalAddWS)
+	prometheus.MustRegister(TotalRemoveWS)
+	prometheus.MustRegister(TotalAddConnectionsForWS)
+	prometheus.MustRegister(TotalRemoveConnectionsForWS)
+	prometheus.MustRegister(TotalTransmitBytesOnWS)
+	prometheus.MustRegister(TotalTransmitErrorBytesOnWS)
+	prometheus.MustRegister(TotalReceiveBytesOnWS)
+	prometheus.MustRegister(TotalAddPeerAttempt)
+	prometheus.MustRegister(TotalPeerConnected)
+	prometheus.MustRegister(TotalPeerDisConnected)
+}
+
 func init() {
 	if os.Getenv(metricsEnv) == "true" {
 		prometheusMetrics = true
-		// Session metrics
-		prometheus.MustRegister(TotalAddWS)
-		prometheus.MustRegister(TotalRemoveWS)
-		prometheus.MustRegister(TotalAddConnectionsForWS)
-		prometheus.MustRegister(TotalRemoveConnectionsForWS)
-		prometheus.MustRegister(TotalTransmitBytesOnWS)
-		prometheus.MustRegister(TotalTransmitErrorBytesOnWS)
-		prometheus.MustRegister(TotalReceiveBytesOnWS)
-		prometheus.MustRegister(TotalAddPeerAttempt)
-		prometheus.MustRegister(TotalPeerConnected)
-		prometheus.MustRegister(TotalPeerDisConnected)
+		Register()
 	}
 }
 


### PR DESCRIPTION
Metrics can only be registered through a magic environment
variable, this enables users to run:

metrics.Register() in main() to register metrics for
collection.

Tested with inlets

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>