### PR TITLE
Fix DefaultErrorWriter status code

### DIFF
--- a/server.go
+++ b/server.go
@@ -20,8 +20,8 @@ type Authorizer func(req *http.Request) (clientKey string, authed bool, err erro
 type ErrorWriter func(rw http.ResponseWriter, req *http.Request, code int, err error)
 
 func DefaultErrorWriter(rw http.ResponseWriter, req *http.Request, code int, err error) {
-	rw.Write([]byte(err.Error()))
 	rw.WriteHeader(code)
+	rw.Write([]byte(err.Error()))
 }
 
 type Server struct {


### PR DESCRIPTION
If WriteHeader has not been called, the status code is set `http.StatusOK` instead of `code`