### PR TITLE
Update logging to error

### DIFF
--- a/server.go
+++ b/server.go
@@ -75,7 +75,7 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	code, err := session.Serve(req.Context())
 	if err != nil {
 		// Hijacked so we can't write to the client
-		logrus.Infof("error in remotedialer server [%d]: %v", code, err)
+		logrus.Errorf("error in remotedialer server [%d]: %v", code, err)
 	}
 }
 


### PR DESCRIPTION
Present error message in logs 

```
[INFO] error in remotedialer server [400]: read tcp 10.252.0.56:443->10.252.1.53:45064: i/o timeout
```

Error supposed to be ;

```
[ERROR] error in remotedialer server [400]: read tcp 10.252.0.56:443->10.252.1.53:45064: i/o timeout
```