### PR TITLE
Fix two metrics descriptions and Register method

### DIFF
--- a/metrics/session_manager.go
+++ b/metrics/session_manager.go
@@ -101,6 +101,9 @@ var (
 // Register registers a series of session
 // metrics for Prometheus.
 func Register() {
+
+	prometheusMetrics = true
+
 	// Session metrics
 	prometheus.MustRegister(TotalAddWS)
 	prometheus.MustRegister(TotalRemoveWS)
@@ -116,7 +119,6 @@ func Register() {
 
 func init() {
 	if os.Getenv(metricsEnv) == "true" {
-		prometheusMetrics = true
 		Register()
 	}
 }

--- a/metrics/session_manager.go
+++ b/metrics/session_manager.go
@@ -49,7 +49,7 @@ var (
 		prometheus.CounterOpts{
 			Subsystem: "session_server",
 			Name:      "total_transmit_bytes",
-			Help:      "Total bytes transmited",
+			Help:      "Total bytes transmitted",
 		},
 		[]string{"clientkey"},
 	)
@@ -58,7 +58,7 @@ var (
 		prometheus.CounterOpts{
 			Subsystem: "session_server",
 			Name:      "total_transmit_error_bytes",
-			Help:      "Total error bytes transmited",
+			Help:      "Total error bytes transmitted",
 		},
 		[]string{"clientkey"},
 	)
@@ -67,7 +67,7 @@ var (
 		prometheus.CounterOpts{
 			Subsystem: "session_server",
 			Name:      "total_receive_bytes",
-			Help:      "Total bytes recieved",
+			Help:      "Total bytes received",
 		},
 		[]string{"clientkey"},
 	)


### PR DESCRIPTION
## Title

Fix a couple of metrics descriptions and fix behaviour of Register method

## Reason for PR

There were a couple of typos that I saw whilst checking out
the metrics code today. This fixes them, and is backwards
compatible since these are only display helpers, not metric
names.

The other fix is for the Register method, which enables Prometheus when called externally from another package. Prior to this change, calling the method had no effect because metrics could only be turned on via the environment variable, if it were set by bash.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>