### PR TITLE
enable TotalPeerDisConnected metrics

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -120,6 +120,7 @@ outer:
 		}
 
 		ws.Close()
+		metrics.IncSMTotalPeerDisConnected(p.id)
 		time.Sleep(5 * time.Second)
 	}
 }


### PR DESCRIPTION
### My Understanding about metrics of websocket connection on peers

According to my understanding, for monitoring websocket connection between rancher-server peers, it usually needs the following metrics. ( I will call rancher-server who sends the establishment request as client, rancher-server who received the establishment request as server)

- **TotalAddPeerAttempt**: It is increased before one rancher-server sends the Websocket connection establishment request to its peers in client rancher-server side

- **TotalPeerConnected**: It is increased after the WebSocket connection is established successfully to its peers in client rancher-server side

- **TotalPeerDisConnected**: It should be increased after the Websocket connection between peers is disconnected in client rancher-server side.

- **TotalAddWS**: It should be increased when the rancher-server finished the Websocket connection establishment by sending the HTTP response in server rancher-server side. 

- **TotalRemoveWS**: It should be increased after agents or peers close the Websocket connection in server rancher-server side

### Issues

- I found, only **TotalPeerDisConnected** isn't enabled

### Why I would like to enable it

1. first of all, I am not sure if rancher developers forget to enable it. It looks like a small mistake.
2. second, as I mentioned, one websocket connection situation between two rancher-server peers usually can be confirm from client side and server side. They are using the different metrics.  During my actual investigation work about websocket connection issue, I can confirm it well in server side, but I cannot confirm if the websocket connection is closed in client side well. We would like to confirm one websocket connection is open or closed by checking metrics of server and client are matched or not

