### PR TITLE
Ignore any errors related to sending pause/resume

### DIFF
--- a/back_pressure.go
+++ b/back_pressure.go
@@ -36,30 +36,24 @@ func (b *backPressure) OnResume() {
 	b.cond.Broadcast()
 }
 
-func (b *backPressure) Pause() error {
+func (b *backPressure) Pause() {
 	b.cond.L.Lock()
 	defer b.cond.L.Unlock()
 	if b.paused {
-		return nil
+		return
 	}
-	if _, err := b.c.Pause(); err != nil {
-		return err
-	}
+	b.c.Pause()
 	b.paused = true
-	return nil
 }
 
-func (b *backPressure) Resume() error {
+func (b *backPressure) Resume() {
 	b.cond.L.Lock()
 	defer b.cond.L.Unlock()
 	if !b.paused {
-		return nil
+		return
 	}
-	if _, err := b.c.Resume(); err != nil {
-		return err
-	}
+	b.c.Resume()
 	b.paused = false
-	return nil
 }
 
 func (b *backPressure) Wait() {

--- a/message.go
+++ b/message.go
@@ -232,9 +232,9 @@ func (m *message) String() string {
 	case RemoveClient:
 		return fmt.Sprintf("%d REMOVECLIENT [%s]", m.id, m.address)
 	case Pause:
-		return fmt.Sprintf("%d PAUSE        [%s]", m.id, m.address)
+		return fmt.Sprintf("%d PAUSE        [%d]", m.id, m.connID)
 	case Resume:
-		return fmt.Sprintf("%d RESUME       [%s]", m.id, m.address)
+		return fmt.Sprintf("%d RESUME       [%d]", m.id, m.connID)
 	}
 	return fmt.Sprintf("%d UNKNOWN[%d]: %d", m.id, m.connID, m.messageType)
 }


### PR DESCRIPTION
Situations like sending a resume on a closed tunnel because EOF has been
reached can cause spurious errors to happen.  Because of this and other
edge cases we ignore an error related to pause/resume sending.

Additionally more logging was added to help see that buffers are fully read.