### PR TITLE
Set buffer log to debug level

### DIFF
--- a/readbuffer.go
+++ b/readbuffer.go
@@ -61,7 +61,7 @@ func (r *readBuffer) Offer(reader io.Reader) error {
 	}
 
 	if r.buf.Len() > MaxBuffer*2 {
-		logrus.Errorf("remotedialer buffer exceeded id=%d, length: %d", r.id, r.buf.Len())
+		logrus.Debugf("remotedialer buffer exceeded id=%d, length: %d", r.id, r.buf.Len())
 	}
 
 	return nil


### PR DESCRIPTION
**Problem:**
The buffer exceeded log was reporting at the error level. Once
the conditions are met, this log can pollute the logs. The
pause/resume mechanism was implemented to handle when the
buffer is full and it should not require user intervention.

**Solution:**
This log is being moved to debug level to reduce noise and
confusion.

**Issue:**
https://github.com/rancher/rancher/issues/36584