### PR TITLE
Add deadline to back pressure wait

### DIFF
--- a/back_pressure.go
+++ b/back_pressure.go
@@ -1,6 +1,7 @@
 package remotedialer
 
 import (
+	"context"
 	"sync"
 )
 
@@ -65,11 +66,12 @@ func (b *backPressure) Resume() {
 	b.paused = false
 }
 
-func (b *backPressure) Wait() {
+func (b *backPressure) Wait(cancel context.CancelFunc) {
 	b.cond.L.Lock()
 	defer b.cond.L.Unlock()
 
 	for !b.closed && b.paused {
 		b.cond.Wait()
+		cancel()
 	}
 }


### PR DESCRIPTION
The connection writer calls Wait before writing the connection. If the
back pressure was paused due to the read buffer exceeding the buffer
limit, it will call Wait on the sync Cond. However, if the connection
was dropped but not explicitly closed, the goroutine will hang and never
wake up again.

This patch works around the issue by adding a deadline to wake up the
condition. If the deadline is exceeded, the connection is formally
closed.