### PR TITLE
Add metrics for pause/resume requests

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -103,19 +103,23 @@ func (c *connection) Write(b []byte) (int, error) {
 }
 
 func (c *connection) OnPause() {
+	metrics.IncSMTTotalPauseReceived(c.session.clientKey)
 	c.backPressure.OnPause()
 }
 
 func (c *connection) OnResume() {
+	metrics.IncSMTTotalResumeReceived(c.session.clientKey)
 	c.backPressure.OnResume()
 }
 
 func (c *connection) Pause() {
+	metrics.IncSMTTotalPauseSent(c.session.clientKey)
 	msg := newPause(c.connID)
 	_, _ = c.session.writeMessage(c.writeDeadline, msg)
 }
 
 func (c *connection) Resume() {
+	metrics.IncSMTTotalResumeSent(c.session.clientKey)
 	msg := newResume(c.connID)
 	_, _ = c.session.writeMessage(c.writeDeadline, msg)
 }

--- a/metrics/session_manager.go
+++ b/metrics/session_manager.go
@@ -96,6 +96,38 @@ var (
 		},
 		[]string{"peer"},
 	)
+	TotalPauseReceived = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: "session_server",
+			Name:      "total_pause_received",
+			Help:      "Total count of pause requests received",
+		},
+		[]string{"clientkey"},
+	)
+	TotalResumeReceived = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: "session_server",
+			Name:      "total_resume_received",
+			Help:      "Total count of resume requests received",
+		},
+		[]string{"clientkey"},
+	)
+	TotalPauseSent = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: "session_server",
+			Name:      "total_pause_sent",
+			Help:      "Total count of pause requests sent",
+		},
+		[]string{"clientkey"},
+	)
+	TotalResumeSent = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: "session_server",
+			Name:      "total_resume_sent",
+			Help:      "Total count of resume requests sent",
+		},
+		[]string{"clientkey"},
+	)
 )
 
 // Register registers a series of session
@@ -115,6 +147,8 @@ func Register() {
 	prometheus.MustRegister(TotalAddPeerAttempt)
 	prometheus.MustRegister(TotalPeerConnected)
 	prometheus.MustRegister(TotalPeerDisConnected)
+	prometheus.MustRegister(TotalPause)
+	prometheus.MustRegister(TotalResume)
 }
 
 func init() {
@@ -229,5 +263,41 @@ func IncSMTotalPeerDisConnected(peer string) {
 				"peer": peer,
 			}).Inc()
 
+	}
+}
+
+func IncSMTTotalPauseReceived(clientKey string) {
+	if prometheusMetrics {
+		TotalPauseReceived.With(
+			prometheus.Labels{
+				"clientkey": clientKey,
+			}).Inc()
+	}
+}
+
+func IncSMTTotalResumeReceived(clientKey string) {
+	if prometheusMetrics {
+		TotalResumeReceived.With(
+			prometheus.Labels{
+				"clientkey": clientKey,
+			}).Inc()
+	}
+}
+
+func IncSMTTotalPauseSent(clientKey string) {
+	if prometheusMetrics {
+		TotalPauseSent.With(
+			prometheus.Labels{
+				"clientkey": clientKey,
+			}).Inc()
+	}
+}
+
+func IncSMTTotalResumeSent(clientKey string) {
+	if prometheusMetrics {
+		TotalResumeSent.With(
+			prometheus.Labels{
+				"clientkey": clientKey,
+			}).Inc()
 	}
 }


### PR DESCRIPTION
Add metrics for pause/resume protocol to help with debugging potential lockups.

Relates to https://github.com/rancher/remotedialer/issues/57