### PR TITLE
Capture and log errors when writing errors

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -124,7 +124,9 @@ func (c *connection) writeErr(err error) {
 	if err != nil {
 		msg := newErrorMessage(c.connID, err)
 		metrics.AddSMTotalTransmitErrorBytesOnWS(c.session.clientKey, float64(len(msg.Bytes())))
-		c.session.writeMessage(c.writeDeadline, msg)
+		if _, err2 := c.session.writeMessage(c.writeDeadline, msg); err2 != nil {
+			logrus.Warnf("encountered error %q while writing error %q to close remotedialer connection %v", err2, err, c.connID)
+		}
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -125,7 +125,7 @@ func (c *connection) writeErr(err error) {
 		msg := newErrorMessage(c.connID, err)
 		metrics.AddSMTotalTransmitErrorBytesOnWS(c.session.clientKey, float64(len(msg.Bytes())))
 		if _, err2 := c.session.writeMessage(c.writeDeadline, msg); err2 != nil {
-			logrus.Warnf("encountered error %q while writing error %q to close remotedialer connection %v", err2, err, c.connID)
+			logrus.Warnf("[%d] encountered error %q while writing error %q to close remotedialer", c.connID, err2, err)
 		}
 	}
 }


### PR DESCRIPTION
Previous code silently discarded an error which could result in goroutines/memory leaks (when `Error` messages are not delivered, the receiver might never `Close()` the `readbuffer` on its end.

Found during investigations in https://github.com/rancher/rancher/issues/44576 [internal reference SURE-7122](https://jira.suse.com/browse/SURE-7122).