### PR TITLE
Add a Read timeout for readbuffer

### DIFF
--- a/readbuffer.go
+++ b/readbuffer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 	"time"
 
@@ -17,7 +18,6 @@ const (
 )
 
 var ErrReadTimeoutExceeded = errors.New("read timeout exceeded")
-var ErrReadDeadlineExceeded = errors.New("deadline exceeded")
 
 type readBuffer struct {
 	id, readCount, offerCount int64
@@ -106,7 +106,7 @@ func (r *readBuffer) Read(b []byte) (int, error) {
 		now := time.Now()
 		if !r.deadline.IsZero() {
 			if now.After(r.deadline) {
-				return 0, ErrReadDeadlineExceeded
+				return 0, fmt.Errorf("remotedialer readbuffer Read deadline exceeded: %w", os.ErrDeadlineExceeded)
 			}
 		}
 

--- a/readbuffer_test.go
+++ b/readbuffer_test.go
@@ -1,0 +1,101 @@
+package remotedialer
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_readBuffer_Read(t *testing.T) {
+	type args struct {
+		b []byte
+	}
+	tests := []struct {
+		name     string
+		args     args
+		deadline time.Duration
+		timeout  time.Duration
+		offer    []byte
+		want     int
+		wantErr  assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Read",
+			args: args{
+				b: make([]byte, 10),
+			},
+			offer:   []byte("test"),
+			want:    4,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Read with timeout",
+			args: args{
+				b: make([]byte, 10),
+			},
+			timeout: 100 * time.Millisecond,
+			want:    0,
+			wantErr: func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+				return assert.Equal(t, err, ErrReadTimeoutExceeded)
+			},
+		},
+		{
+			name: "Read with deadline",
+			args: args{
+				b: make([]byte, 10),
+			},
+			deadline: 100 * time.Millisecond,
+			offer:    nil,
+			want:     0,
+			wantErr: func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+				return assert.Equal(t, err, ErrReadDeadlineExceeded)
+			},
+		},
+		{
+			name: "Read with timeout and deadline",
+			args: args{
+				b: make([]byte, 10),
+			},
+			deadline: 50 * time.Millisecond,
+			offer:    nil,
+			want:     0,
+			wantErr: func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+				return assert.Equal(t, err, ErrReadDeadlineExceeded)
+			},
+		},
+	}
+
+	t.Parallel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &readBuffer{
+				id:           1,
+				backPressure: newBackPressure(nil),
+				cond: sync.Cond{
+					L: &sync.Mutex{},
+				},
+			}
+			if tt.deadline > 0 {
+				r.deadline = time.Now().Add(tt.deadline)
+			}
+			if tt.timeout > 0 {
+				r.readTimeout = tt.timeout
+			}
+			if tt.offer != nil {
+				err := r.Offer(bytes.NewReader(tt.offer))
+				if err != nil {
+					t.Errorf("Offer() returned error: %v", err)
+				}
+			}
+			got, err := r.Read(tt.args.b)
+			if !tt.wantErr(t, err, fmt.Sprintf("Read(%v)", tt.args.b)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "Read(%v)", tt.args.b)
+		})
+	}
+}

--- a/readbuffer_test.go
+++ b/readbuffer_test.go
@@ -3,6 +3,7 @@ package remotedialer
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -40,7 +41,7 @@ func Test_readBuffer_Read(t *testing.T) {
 			timeout: 100 * time.Millisecond,
 			want:    0,
 			wantErr: func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
-				return assert.Equal(t, err, ErrReadTimeoutExceeded)
+				return assert.ErrorIs(t, err, ErrReadTimeoutExceeded)
 			},
 		},
 		{
@@ -52,7 +53,7 @@ func Test_readBuffer_Read(t *testing.T) {
 			offer:    nil,
 			want:     0,
 			wantErr: func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
-				return assert.Equal(t, err, ErrReadDeadlineExceeded)
+				return assert.ErrorIs(t, err, os.ErrDeadlineExceeded)
 			},
 		},
 		{
@@ -64,7 +65,7 @@ func Test_readBuffer_Read(t *testing.T) {
 			offer:    nil,
 			want:     0,
 			wantErr: func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
-				return assert.Equal(t, err, ErrReadDeadlineExceeded)
+				return assert.ErrorIs(t, err, os.ErrDeadlineExceeded)
 			},
 		},
 	}


### PR DESCRIPTION
`Read()` may wait forever if no deadline is set and no calls to `Close()` are made, causing goroutine and memory leaks.

This patch adds a read timeout in case no deadline is set, calling `Close()` if more than `DefaultReadTimeout` elapses. It is meant to be a last line of defense if all else fails closing the connection.

Such a problematic condition was observed in Rancher 2.7.6 (https://github.com/rancher/rancher/issues/44576 [internal reference SURE-7122](https://jira.suse.com/browse/SURE-7122)), specifically with `remotedialer.pipe()` calls blocked by `Read()` on the rancher pods. In that scenario, `Close()` is expected to be called upon receiving `Error` messages, but those might never be delivered at all, eg. because of write timeouts at the sending end.

Please note this mechanism is meant as a robustness measure - in general trust in network communication/well-behaving clients cannot guaranteed for cleanups. Nevertheless any systematic causes should be analyzed and addressed individually wherever possible (in the specific case investigation continues via https://github.com/rancher/remotedialer/pull/67).

Credits to @aruiz14 for finding the crucial piece of the puzzle in this investigation.

This patch was tested by an affected user and it noticeably helped in keeping the number of Rancher goroutines (summed over the three replica pods) under control:

![image](https://github.com/rancher/remotedialer/assets/250541/6b1323ee-f4f3-40b3-af52-4023e8f1da39)

