### PR TITLE
Make client and server to resync active connections

### DIFF
--- a/client_dialer.go
+++ b/client_dialer.go
@@ -38,7 +38,7 @@ func pipe(client *connection, server net.Conn) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
-	close := func(err error) error {
+	closePipe := func(err error) error {
 		if err == nil {
 			err = io.EOF
 		}
@@ -50,11 +50,11 @@ func pipe(client *connection, server net.Conn) {
 	go func() {
 		defer wg.Done()
 		_, err := io.Copy(server, client)
-		close(err)
+		closePipe(err)
 	}()
 
 	_, err := io.Copy(client, server)
-	err = close(err)
+	err = closePipe(err)
 	wg.Wait()
 
 	// Write tunnel error after no more I/O is happening, just incase messages get out of order

--- a/connection.go
+++ b/connection.go
@@ -36,7 +36,6 @@ func newConnection(connID int64, session *Session, proto, address string) *conne
 }
 
 func (c *connection) tunnelClose(err error) {
-	metrics.IncSMTotalRemoveConnectionsForWS(c.session.clientKey, c.addr.Network(), c.addr.String())
 	c.writeErr(err)
 	c.doTunnelClose(err)
 }
@@ -46,6 +45,7 @@ func (c *connection) doTunnelClose(err error) {
 		return
 	}
 
+	metrics.IncSMTotalRemoveConnectionsForWS(c.session.clientKey, c.addr.Network(), c.addr.String())
 	c.err = err
 	if c.err == nil {
 		c.err = io.ErrClosedPipe

--- a/message.go
+++ b/message.go
@@ -32,6 +32,7 @@ const (
 	Pause
 	// Resume is a message type used to resume a paused connection
 	Resume
+	SyncConnections
 )
 
 var (
@@ -244,6 +245,8 @@ func (m *message) String() string {
 		return fmt.Sprintf("%d PAUSE        [%d]", m.id, m.connID)
 	case Resume:
 		return fmt.Sprintf("%d RESUME       [%d]", m.id, m.connID)
+	case SyncConnections:
+		return fmt.Sprintf("%d SYNCCONNS    [%d]", m.id, m.connID)
 	}
 	return fmt.Sprintf("%d UNKNOWN[%d]: %d", m.id, m.connID, m.messageType)
 }

--- a/message.go
+++ b/message.go
@@ -32,6 +32,8 @@ const (
 	Pause
 	// Resume is a message type used to resume a paused connection
 	Resume
+	// SyncConnections is a message type used to communicate active connection IDs.
+	// The received can consider any ID not present in this message as stale and free any associated resource.
 	SyncConnections
 )
 

--- a/message.go
+++ b/message.go
@@ -33,7 +33,7 @@ const (
 	// Resume is a message type used to resume a paused connection
 	Resume
 	// SyncConnections is a message type used to communicate active connection IDs.
-	// The received can consider any ID not present in this message as stale and free any associated resource.
+	// The receiver can consider any ID not present in this message as stale and free any associated resource.
 	SyncConnections
 )
 

--- a/session.go
+++ b/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -103,6 +104,19 @@ func (s *Session) getConnection(connID int64) *connection {
 	defer s.RUnlock()
 
 	return s.conns[connID]
+}
+
+// activeConnectionIDs returns an ordered list of IDs for the currently active connections
+func (s *Session) activeConnectionIDs() []int64 {
+	s.RLock()
+	defer s.RUnlock()
+
+	res := make([]int64, 0, len(s.conns))
+	for id := range s.conns {
+		res = append(res, id)
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i] < res[j] })
+	return res
 }
 
 // addSessionKey registers a new session key for a given client key

--- a/session.go
+++ b/session.go
@@ -162,10 +162,17 @@ func (s *Session) startPings(rootCtx context.Context) {
 		t := time.NewTicker(PingWriteInterval)
 		defer t.Stop()
 
+		syncConnections := time.NewTicker(SyncConnectionsInterval)
+		defer syncConnections.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
+			case <-syncConnections.C:
+				if err := s.sendSyncConnections(); err != nil {
+					logrus.WithError(err).Error("Error syncing connections")
+				}
 			case <-t.C:
 				if err := s.sendPing(); err != nil {
 					logrus.WithError(err).Error("Error writing ping")

--- a/session.go
+++ b/session.go
@@ -84,15 +84,16 @@ func (s *Session) removeConnection(connID int64) *connection {
 	s.Lock()
 	defer s.Unlock()
 
-	conn := s.lockedRemoveConnection(connID)
+	conn := s.removeConnectionLocked(connID)
 	if PrintTunnelData {
 		defer logrus.Debugf("CONNECTIONS %d %d", s.sessionKey, len(s.conns))
 	}
 	return conn
 }
 
-// lockedRemoveConnection removes a given connection from the session. The session lock must be held by the caller when calling this method
-func (s *Session) lockedRemoveConnection(connID int64) *connection {
+// removeConnectionLocked removes a given connection from the session.
+// The session lock must be held by the caller when calling this method
+func (s *Session) removeConnectionLocked(connID int64) *connection {
 	conn := s.conns[connID]
 	delete(s.conns, connID)
 	return conn

--- a/session_serve.go
+++ b/session_serve.go
@@ -100,7 +100,7 @@ func (s *Session) syncConnections(r io.Reader) error {
 		return fmt.Errorf("decoding sync connections payload: %w", err)
 	}
 
-	s.closeStaleConnections(clientActiveConnections)
+	s.compareAndCloseStaleConnections(clientActiveConnections)
 	return nil
 }
 

--- a/session_serve.go
+++ b/session_serve.go
@@ -95,8 +95,13 @@ func (s *Session) syncConnections(r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("reading message body: %w", err)
 	}
+	clientActiveConnections, err := decodeConnectionIDs(payload)
+	if err != nil {
+		return fmt.Errorf("decoding sync connections payload: %w", err)
+	}
 
-	return s.lockedSyncConnections(payload)
+	s.closeStaleConnections(clientActiveConnections)
+	return nil
 }
 
 // closeConnection removes a connection for a given ID from the session, sending an error message to communicate the closing to the other end.

--- a/session_sync.go
+++ b/session_sync.go
@@ -58,7 +58,7 @@ func (s *Session) closeStaleConnections(clientIDs []int64) {
 	defer s.Unlock()
 	for _, id := range toClose {
 		// Connection no longer active in the client, close it server-side
-		conn := s.lockedRemoveConnection(id)
+		conn := s.removeConnectionLocked(id)
 		if conn != nil {
 			// Using doTunnelClose directly instead of tunnelClose, omitting unnecessarily sending an Error message
 			conn.doTunnelClose(errCloseSyncConnections)

--- a/session_sync.go
+++ b/session_sync.go
@@ -45,9 +45,8 @@ func (s *Session) sendSyncConnections() error {
 	return err
 }
 
-// closeMissingConnections closes any session connection that is not present in the IDs received from the client
-// The session lock must be hold by the caller when calling this method
-func (s *Session) closeStaleConnections(clientIDs []int64) {
+// compareAndCloseStaleConnections compares the Session's activeConnectionIDs with the provided list from the client, then closing every connection not present in it
+func (s *Session) compareAndCloseStaleConnections(clientIDs []int64) {
 	serverIDs := s.activeConnectionIDs()
 	toClose := diffSortedSetsGetRemoved(serverIDs, clientIDs)
 	if len(toClose) == 0 {

--- a/session_sync.go
+++ b/session_sync.go
@@ -67,7 +67,8 @@ func (s *Session) compareAndCloseStaleConnections(clientIDs []int64) {
 
 // diffSortedSetsGetRemoved compares two sorted slices and returns those items present in a that are not present in b
 // similar to coreutil's "comm -23"
-func diffSortedSetsGetRemoved(a, b []int64) (res []int64) {
+func diffSortedSetsGetRemoved(a, b []int64) []int64 {
+	var res []int64
 	var i, j int
 	for i < len(a) && j < len(b) {
 		if a[i] < b[j] { // present in "a", not in "b"
@@ -81,5 +82,5 @@ func diffSortedSetsGetRemoved(a, b []int64) (res []int64) {
 		}
 	}
 	res = append(res, a[i:]...) // any remainders in "a" are also removed from "b"
-	return
+	return res
 }

--- a/session_sync.go
+++ b/session_sync.go
@@ -26,3 +26,11 @@ func decodeConnectionIDs(payload []byte) ([]int64, error) {
 	}
 	return result, nil
 }
+
+func newSyncConnectionsMessage(connectionIDs []int64) *message {
+	return &message{
+		id:          nextid(),
+		messageType: SyncConnections,
+		bytes:       encodeConnectionIDs(connectionIDs),
+	}
+}

--- a/session_sync.go
+++ b/session_sync.go
@@ -49,7 +49,7 @@ func (s *Session) sendSyncConnections() error {
 // The session lock must be hold by the caller when calling this method
 func (s *Session) closeStaleConnections(clientIDs []int64) {
 	serverIDs := s.activeConnectionIDs()
-	toClose := removedFromSlice(serverIDs, clientIDs)
+	toClose := diffSortedSetsGetRemoved(serverIDs, clientIDs)
 	if len(toClose) == 0 {
 		return
 	}
@@ -66,9 +66,9 @@ func (s *Session) closeStaleConnections(clientIDs []int64) {
 	}
 }
 
-// removedFromSlice compares two sorted slices and returns those items present in a that are not present in b
+// diffSortedSetsGetRemoved compares two sorted slices and returns those items present in a that are not present in b
 // similar to coreutil's "comm -23"
-func removedFromSlice(a, b []int64) (res []int64) {
+func diffSortedSetsGetRemoved(a, b []int64) (res []int64) {
 	var i, j int
 	for i < len(a) && j < len(b) {
 		if a[i] < b[j] { // present in "a", not in "b"

--- a/session_sync.go
+++ b/session_sync.go
@@ -66,6 +66,8 @@ func (s *Session) closeStaleConnections(clientIDs []int64) {
 	}
 }
 
+// removedFromSlice compares two sorted slices and returns those items present in a that are not present in b
+// similar to coreutil's "comm -23"
 func removedFromSlice(a, b []int64) (res []int64) {
 	var i, j int
 	for i < len(a) && j < len(b) {

--- a/session_sync.go
+++ b/session_sync.go
@@ -2,8 +2,12 @@ package remotedialer
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"time"
 )
+
+var errCloseSyncConnections = errors.New("sync from client")
 
 // encodeConnectionIDs serializes a slice of connection IDs
 func encodeConnectionIDs(ids []int64) []byte {
@@ -33,4 +37,43 @@ func newSyncConnectionsMessage(connectionIDs []int64) *message {
 		messageType: SyncConnections,
 		bytes:       encodeConnectionIDs(connectionIDs),
 	}
+}
+
+// sendSyncConnections sends a binary message of type SyncConnections, whose payload is a list of the active connection IDs for this session
+func (s *Session) sendSyncConnections() error {
+	_, err := s.writeMessage(time.Now().Add(SyncConnectionsTimeout), newSyncConnectionsMessage(s.activeConnectionIDs()))
+	return err
+}
+
+// lockedSyncConnections closes any session connection that is not present in the IDs received from the client
+// The session lock must be hold by the caller when calling this method
+func (s *Session) lockedSyncConnections(payload []byte) error {
+	clientIDs, err := decodeConnectionIDs(payload)
+	if err != nil {
+		return fmt.Errorf("decoding sync connections payload: %w", err)
+	}
+	for _, id := range s.activeConnectionIDs() {
+		if i := sliceIndex(clientIDs, id); i >= 0 {
+			// Connection is still active, do nothing
+			clientIDs = append(clientIDs[:i], clientIDs[i+1:]...) // IDs are unique, skip in next iteration
+			continue
+		}
+
+		// Connection no longer active in the client, close it server-side
+		conn := s.lockedRemoveConnection(id)
+		if conn != nil {
+			// Using doTunnelClose directly instead of tunnelClose, omitting unnecessarily sending an Error message
+			conn.doTunnelClose(errCloseSyncConnections)
+		}
+	}
+	return nil
+}
+
+func sliceIndex(s []int64, id int64) int {
+	for x := range s {
+		if s[x] == id {
+			return x
+		}
+	}
+	return -1
 }

--- a/session_sync.go
+++ b/session_sync.go
@@ -1,0 +1,28 @@
+package remotedialer
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// encodeConnectionIDs serializes a slice of connection IDs
+func encodeConnectionIDs(ids []int64) []byte {
+	payload := make([]byte, 0, 8*len(ids))
+	for _, id := range ids {
+		payload = binary.LittleEndian.AppendUint64(payload, uint64(id))
+	}
+	return payload
+}
+
+// decodeConnectionIDs deserializes a slice of connection IDs
+func decodeConnectionIDs(payload []byte) ([]int64, error) {
+	if len(payload)%8 != 0 {
+		return nil, fmt.Errorf("incorrect data format")
+	}
+	result := make([]int64, 0, len(payload)/8)
+	for x := 0; x < len(payload); x += 8 {
+		id := binary.LittleEndian.Uint64(payload[x : x+8])
+		result = append(result, int64(id))
+	}
+	return result, nil
+}

--- a/session_sync_test.go
+++ b/session_sync_test.go
@@ -41,12 +41,12 @@ func Test_encodeConnectionIDs(t *testing.T) {
 	}
 }
 
-func Test_removedFromSlice(t *testing.T) {
+func Test_diffSortedSetsGetRemoved(t *testing.T) {
 	server := []int64{3, 5, 20, 50, 100}
 	client := []int64{3, 50, 100, 200}
 	expected := []int64{5, 20}
 
-	if got, want := removedFromSlice(server, client), expected; !reflect.DeepEqual(got, want) {
+	if got, want := diffSortedSetsGetRemoved(server, client), expected; !reflect.DeepEqual(got, want) {
 		t.Errorf("unexpected result, got: %v, want: %v", got, want)
 	}
 }

--- a/session_sync_test.go
+++ b/session_sync_test.go
@@ -27,7 +27,8 @@ func Test_encodeConnectionIDs(t *testing.T) {
 		{100},
 		{1000},
 	}
-	for _, tt := range tests {
+	for x := range tests {
+		tt := tests[x]
 		t.Run(fmt.Sprintf("%d_ids", tt.size), func(t *testing.T) {
 			t.Parallel()
 			ids := generateIDs(tt.size)
@@ -73,7 +74,8 @@ func Test_diffSortedSetsGetRemoved(t *testing.T) {
 			expected: []int64{1, 2, 4, 5},
 		},
 	}
-	for x, tt := range tests {
+	for x := range tests {
+		tt := tests[x]
 		t.Run(fmt.Sprintf("case_%d", x), func(t *testing.T) {
 			t.Parallel()
 			if got, want := diffSortedSetsGetRemoved(tt.server, tt.client), tt.expected; !reflect.DeepEqual(got, want) {

--- a/session_sync_test.go
+++ b/session_sync_test.go
@@ -41,6 +41,16 @@ func Test_encodeConnectionIDs(t *testing.T) {
 	}
 }
 
+func Test_removedFromSlice(t *testing.T) {
+	server := []int64{3, 5, 20, 50, 100}
+	client := []int64{3, 50, 100, 200}
+	expected := []int64{5, 20}
+
+	if got, want := removedFromSlice(server, client), expected; !reflect.DeepEqual(got, want) {
+		t.Errorf("unexpected result, got: %v, want: %v", got, want)
+	}
+}
+
 func TestSession_sendSyncConnections(t *testing.T) {
 	data := make(chan []byte)
 	conn := testServerWS(t, data)

--- a/session_sync_test.go
+++ b/session_sync_test.go
@@ -1,0 +1,42 @@
+package remotedialer
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+func Test_encodeConnectionIDs(t *testing.T) {
+	tests := []struct {
+		size int
+	}{
+		{0},
+		{1},
+		{2},
+		{10},
+		{100},
+		{1000},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d_ids", tt.size), func(t *testing.T) {
+			ids := generateIDs(tt.size)
+			encoded := encodeConnectionIDs(ids)
+			decoded, err := decodeConnectionIDs(encoded)
+			if err != nil {
+				t.Error(err)
+			}
+			if got, want := decoded, ids; !reflect.DeepEqual(got, want) {
+				t.Errorf("encoding and decoding differs from original data, got: %v, want: %v", got, want)
+			}
+		})
+	}
+}
+
+func generateIDs(n int) []int64 {
+	ids := make([]int64, n)
+	for x := range ids {
+		ids[x] = rand.Int63()
+	}
+	return ids
+}

--- a/session_sync_test.go
+++ b/session_sync_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func Test_encodeConnectionIDs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		size int
 	}{
@@ -28,6 +29,7 @@ func Test_encodeConnectionIDs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%d_ids", tt.size), func(t *testing.T) {
+			t.Parallel()
 			ids := generateIDs(tt.size)
 			encoded := encodeConnectionIDs(ids)
 			decoded, err := decodeConnectionIDs(encoded)
@@ -52,6 +54,8 @@ func Test_diffSortedSetsGetRemoved(t *testing.T) {
 }
 
 func TestSession_sendSyncConnections(t *testing.T) {
+	t.Parallel()
+
 	data := make(chan []byte)
 	conn := testServerWS(t, data)
 	session := newSession(rand.Int63(), "sync-test", newWSConn(conn))

--- a/session_sync_test.go
+++ b/session_sync_test.go
@@ -44,12 +44,42 @@ func Test_encodeConnectionIDs(t *testing.T) {
 }
 
 func Test_diffSortedSetsGetRemoved(t *testing.T) {
-	server := []int64{3, 5, 20, 50, 100}
-	client := []int64{3, 50, 100, 200}
-	expected := []int64{5, 20}
-
-	if got, want := diffSortedSetsGetRemoved(server, client), expected; !reflect.DeepEqual(got, want) {
-		t.Errorf("unexpected result, got: %v, want: %v", got, want)
+	t.Parallel()
+	tests := []struct {
+		server, client, expected []int64
+	}{
+		{
+			// same ids
+			server:   []int64{2, 4, 6},
+			client:   []int64{2, 4, 6},
+			expected: nil,
+		},
+		{
+			// Client keeps all ids from the server, additional ids are okay
+			server:   []int64{1, 2, 3},
+			client:   []int64{1, 2, 3, 4, 5},
+			expected: nil,
+		},
+		{
+			// Client closed some ids kept by the server
+			server:   []int64{1, 2, 3, 4, 5},
+			client:   []int64{1, 2, 3},
+			expected: []int64{4, 5},
+		},
+		{
+			// Combined case
+			server:   []int64{1, 2, 3, 4, 5},
+			client:   []int64{3, 6},
+			expected: []int64{1, 2, 4, 5},
+		},
+	}
+	for x, tt := range tests {
+		t.Run(fmt.Sprintf("case_%d", x), func(t *testing.T) {
+			t.Parallel()
+			if got, want := diffSortedSetsGetRemoved(tt.server, tt.client), tt.expected; !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected result, got: %v, want: %v", got, want)
+			}
+		})
 	}
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -42,6 +42,8 @@ func setupDummySession(t *testing.T, nConnections int) *Session {
 }
 
 func TestSession_connections(t *testing.T) {
+	t.Parallel()
+
 	const n = 10
 	s := setupDummySession(t, n)
 
@@ -59,6 +61,8 @@ func TestSession_connections(t *testing.T) {
 }
 
 func TestSession_sessionKeys(t *testing.T) {
+	t.Parallel()
+
 	s := setupDummySession(t, 0)
 
 	clientKey, sessionKey := "testkey", rand.Int()
@@ -78,6 +82,7 @@ func TestSession_sessionKeys(t *testing.T) {
 }
 
 func TestSession_activeConnectionIDs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		conns    map[int64]*connection
@@ -107,6 +112,7 @@ func TestSession_activeConnectionIDs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			session := Session{conns: tt.conns}
 			if got, want := session.activeConnectionIDs(), tt.expected; !reflect.DeepEqual(got, want) {
 				t.Errorf("incorrect result, got: %v, want: %v", got, want)
@@ -116,6 +122,8 @@ func TestSession_activeConnectionIDs(t *testing.T) {
 }
 
 func TestSession_sendPings(t *testing.T) {
+	t.Parallel()
+
 	conn := testServerWS(t, nil)
 	session := newSession(rand.Int63(), "pings-test", newWSConn(conn))
 

--- a/session_test.go
+++ b/session_test.go
@@ -110,7 +110,8 @@ func TestSession_activeConnectionIDs(t *testing.T) {
 			expected: []int64{3, 5, 20},
 		},
 	}
-	for _, tt := range tests {
+	for x := range tests {
+		tt := tests[x]
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			session := Session{conns: tt.conns}

--- a/types.go
+++ b/types.go
@@ -3,8 +3,10 @@ package remotedialer
 import "time"
 
 const (
-	PingWaitDuration  = 60 * time.Second
-	PingWriteInterval = 5 * time.Second
-	MaxRead           = 8192
-	HandshakeTimeOut  = 10 * time.Second
+	PingWaitDuration        = 60 * time.Second
+	PingWriteInterval       = 5 * time.Second
+	SyncConnectionsInterval = 60 * time.Second
+	SyncConnectionsTimeout  = 60 * time.Second
+	MaxRead                 = 8192
+	HandshakeTimeOut        = 10 * time.Second
 )

--- a/types.go
+++ b/types.go
@@ -3,10 +3,12 @@ package remotedialer
 import "time"
 
 const (
-	PingWaitDuration        = 60 * time.Second
-	PingWriteInterval       = 5 * time.Second
+	PingWaitDuration  = 60 * time.Second
+	PingWriteInterval = 5 * time.Second
+	// SyncConnectionsInterval is the time after which the client will send the list of active connection IDs
 	SyncConnectionsInterval = 60 * time.Second
-	SyncConnectionsTimeout  = 60 * time.Second
-	MaxRead                 = 8192
-	HandshakeTimeOut        = 10 * time.Second
+	// SyncConnectionsTimeout sets the maximum duration for a SyncConnections operation
+	SyncConnectionsTimeout = 60 * time.Second
+	MaxRead                = 8192
+	HandshakeTimeOut       = 10 * time.Second
 )


### PR DESCRIPTION
## Issue: [44576](https://github.com/rancher/rancher/issues/44576)

Relates to #68
Depends on #78

## Problem

remotedialer allows multiplexing connections between two peers using a single websocket connections by including a connection ID in the messages and using separate buffers. The protocol specifies different message types for different actions (`Connect`, `Data`, `Error`, `Pause`, `Resume`, etc.). In particular, the `Error` type is used to communicate the other end that a certain connection must be closed. However, depending on the cause of the original error, this message may never be successfully transmitted, as the sender will give up on sending it (#67 adds additional logging for this situation).

When this happens, one of the peers will never receive a termination message for that connection, making the underlying buffers to get stuck on `Read()` forever, hence causing goroutine and memory leaks.

## Solution

This PR adds a new message type to the protocol (`Resync`), whose payload contains a list of connection IDs. Similarly to how clients sends `Ping` control messages, `Resync` messages will periodically tell the receiving peer that any connection not contained in the provided list is no longer needed and can be pruned.

Small caveat: we cannot use Control messages for this purpose, since websocket set a limit of 125 bytes for their payload, which would impose a tight restriction on the number of connections.

## CheckList

- [X] Test
