### PR TITLE
Refactor Session serveMessage and mutex usage

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -54,13 +54,13 @@ func (c *connection) doTunnelClose(err error) {
 	c.buffer.Close(c.err)
 }
 
-func (c *connection) OnData(m *message) error {
+func (c *connection) OnData(r io.Reader) error {
 	if PrintTunnelData {
 		defer func() {
 			logrus.Debugf("ONDATA  [%d] %s", c.connID, c.buffer.Status())
 		}()
 	}
-	return c.buffer.Offer(m.body)
+	return c.buffer.Offer(r)
 }
 
 func (c *connection) Close() error {

--- a/message.go
+++ b/message.go
@@ -220,7 +220,7 @@ func (m *message) Read(p []byte) (int, error) {
 	return m.body.Read(p)
 }
 
-func (m *message) WriteTo(deadline time.Time, wsConn *wsConn) (int, error) {
+func (m *message) WriteTo(deadline time.Time, wsConn wsConn) (int, error) {
 	err := wsConn.WriteMessage(websocket.BinaryMessage, deadline, m.Bytes())
 	return len(m.bytes), err
 }

--- a/message.go
+++ b/message.go
@@ -16,12 +16,21 @@ import (
 )
 
 const (
+	// Data is the main message type, used to transport application data
 	Data messageType = iota + 1
+	// Connect is a control message type, used to request opening a new connection
 	Connect
+	// Error is a message type used to send an error during the communication.
+	// Any receiver of an Error message can assume the connection can be closed.
+	// io.EOF is used for graceful termination of connections.
 	Error
+	// AddClient is a message type used to open a new client to the peering session
 	AddClient
+	// RemoveClient is a message type used to remove an existing client from a peering session
 	RemoveClient
+	// Pause is a message type used to temporarily stop a given connection
 	Pause
+	// Resume is a message type used to resume a paused connection
 	Resume
 )
 

--- a/session.go
+++ b/session.go
@@ -67,6 +67,12 @@ func newSession(sessionKey int64, clientKey string, conn *websocket.Conn) *Sessi
 	}
 }
 
+func (s *Session) getConnection(connID int64) *connection {
+	s.Lock()
+	defer s.Unlock()
+	return s.conns[connID]
+}
+
 func (s *Session) startPings(rootCtx context.Context) {
 	ctx, cancel := context.WithCancel(rootCtx)
 	s.pingCancel = cancel

--- a/session.go
+++ b/session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"strconv"
@@ -125,61 +124,6 @@ func (s *Session) Serve(ctx context.Context) (int, error) {
 	}
 }
 
-func (s *Session) serveMessage(ctx context.Context, reader io.Reader) error {
-	message, err := newServerMessage(reader)
-	if err != nil {
-		return err
-	}
-
-	if PrintTunnelData {
-		logrus.Debug("REQUEST ", message)
-	}
-
-	if message.messageType == Connect {
-		if s.auth == nil || !s.auth(message.proto, message.address) {
-			return errors.New("connect not allowed")
-		}
-		s.clientConnect(ctx, message)
-		return nil
-	}
-
-	s.Lock()
-	if message.messageType == AddClient && s.remoteClientKeys != nil {
-		err := s.addRemoteClient(message.address)
-		s.Unlock()
-		return err
-	} else if message.messageType == RemoveClient {
-		err := s.removeRemoteClient(message.address)
-		s.Unlock()
-		return err
-	}
-	conn := s.conns[message.connID]
-	s.Unlock()
-
-	if conn == nil {
-		if message.messageType == Data {
-			err := fmt.Errorf("connection not found %s/%d/%d", s.clientKey, s.sessionKey, message.connID)
-			newErrorMessage(message.connID, err).WriteTo(defaultDeadline(), s.conn)
-		}
-		return nil
-	}
-
-	switch message.messageType {
-	case Data:
-		if err := conn.OnData(message); err != nil {
-			s.closeConnection(message.connID, err)
-		}
-	case Pause:
-		conn.OnPause()
-	case Resume:
-		conn.OnResume()
-	case Error:
-		s.closeConnection(message.connID, message.Err())
-	}
-
-	return nil
-}
-
 func defaultDeadline() time.Time {
 	return time.Now().Add(time.Minute)
 }
@@ -191,72 +135,6 @@ func parseAddress(address string) (string, int, error) {
 	}
 	v, err := strconv.Atoi(parts[1])
 	return parts[0], v, err
-}
-
-func (s *Session) addRemoteClient(address string) error {
-	clientKey, sessionKey, err := parseAddress(address)
-	if err != nil {
-		return fmt.Errorf("invalid remote Session %s: %v", address, err)
-	}
-
-	keys := s.remoteClientKeys[clientKey]
-	if keys == nil {
-		keys = map[int]bool{}
-		s.remoteClientKeys[clientKey] = keys
-	}
-	keys[sessionKey] = true
-
-	if PrintTunnelData {
-		logrus.Debugf("ADD REMOTE CLIENT %s, SESSION %d", address, s.sessionKey)
-	}
-
-	return nil
-}
-
-func (s *Session) removeRemoteClient(address string) error {
-	clientKey, sessionKey, err := parseAddress(address)
-	if err != nil {
-		return fmt.Errorf("invalid remote Session %s: %v", address, err)
-	}
-
-	keys := s.remoteClientKeys[clientKey]
-	delete(keys, int(sessionKey))
-	if len(keys) == 0 {
-		delete(s.remoteClientKeys, clientKey)
-	}
-
-	if PrintTunnelData {
-		logrus.Debugf("REMOVE REMOTE CLIENT %s, SESSION %d", address, s.sessionKey)
-	}
-
-	return nil
-}
-
-func (s *Session) closeConnection(connID int64, err error) {
-	s.Lock()
-	conn := s.conns[connID]
-	delete(s.conns, connID)
-	if PrintTunnelData {
-		logrus.Debugf("CONNECTIONS %d %d", s.sessionKey, len(s.conns))
-	}
-	s.Unlock()
-
-	if conn != nil {
-		conn.tunnelClose(err)
-	}
-}
-
-func (s *Session) clientConnect(ctx context.Context, message *message) {
-	conn := newConnection(message.connID, s, message.proto, message.address)
-
-	s.Lock()
-	s.conns[message.connID] = conn
-	if PrintTunnelData {
-		logrus.Debugf("CONNECTIONS %d %d", s.sessionKey, len(s.conns))
-	}
-	s.Unlock()
-
-	go clientDial(ctx, s.dialer, conn, message)
 }
 
 type connResult struct {

--- a/session.go
+++ b/session.go
@@ -126,8 +126,8 @@ func (s *Session) removeSessionKey(clientKey string, sessionKey int) {
 
 // getSessionKeys retrieves all session keys for a given client key
 func (s *Session) getSessionKeys(clientKey string) map[int]bool {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 	return s.remoteClientKeys[clientKey]
 }
 

--- a/session_manager.go
+++ b/session_manager.go
@@ -77,9 +77,7 @@ func (sm *sessionManager) getDialer(clientKey string) (Dialer, error) {
 
 	for _, sessions := range sm.peers {
 		for _, session := range sessions {
-			session.Lock()
-			keys := session.remoteClientKeys[clientKey]
-			session.Unlock()
+			keys := session.getSessionKeys(clientKey)
 			if len(keys) > 0 {
 				return toDialer(session, clientKey), nil
 			}

--- a/session_manager.go
+++ b/session_manager.go
@@ -89,7 +89,7 @@ func (sm *sessionManager) getDialer(clientKey string) (Dialer, error) {
 
 func (sm *sessionManager) add(clientKey string, conn *websocket.Conn, peer bool) *Session {
 	sessionKey := rand.Int63()
-	session := newSession(sessionKey, clientKey, conn)
+	session := newSession(sessionKey, clientKey, newWSConn(conn))
 
 	sm.Lock()
 	defer sm.Unlock()

--- a/session_serve.go
+++ b/session_serve.go
@@ -1,0 +1,131 @@
+package remotedialer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+func (s *Session) serveMessage(ctx context.Context, reader io.Reader) error {
+	message, err := newServerMessage(reader)
+	if err != nil {
+		return err
+	}
+
+	if PrintTunnelData {
+		logrus.Debug("REQUEST ", message)
+	}
+
+	if message.messageType == Connect {
+		if s.auth == nil || !s.auth(message.proto, message.address) {
+			return errors.New("connect not allowed")
+		}
+		s.clientConnect(ctx, message)
+		return nil
+	}
+
+	s.Lock()
+	if message.messageType == AddClient && s.remoteClientKeys != nil {
+		err := s.addRemoteClient(message.address)
+		s.Unlock()
+		return err
+	} else if message.messageType == RemoveClient {
+		err := s.removeRemoteClient(message.address)
+		s.Unlock()
+		return err
+	}
+	conn := s.conns[message.connID]
+	s.Unlock()
+
+	if conn == nil {
+		if message.messageType == Data {
+			err := fmt.Errorf("connection not found %s/%d/%d", s.clientKey, s.sessionKey, message.connID)
+			newErrorMessage(message.connID, err).WriteTo(defaultDeadline(), s.conn)
+		}
+		return nil
+	}
+
+	switch message.messageType {
+	case Data:
+		if err := conn.OnData(message); err != nil {
+			s.closeConnection(message.connID, err)
+		}
+	case Pause:
+		conn.OnPause()
+	case Resume:
+		conn.OnResume()
+	case Error:
+		s.closeConnection(message.connID, message.Err())
+	}
+
+	return nil
+}
+
+func (s *Session) clientConnect(ctx context.Context, message *message) {
+	conn := newConnection(message.connID, s, message.proto, message.address)
+
+	s.Lock()
+	s.conns[message.connID] = conn
+	if PrintTunnelData {
+		logrus.Debugf("CONNECTIONS %d %d", s.sessionKey, len(s.conns))
+	}
+	s.Unlock()
+
+	go clientDial(ctx, s.dialer, conn, message)
+}
+
+func (s *Session) addRemoteClient(address string) error {
+	clientKey, sessionKey, err := parseAddress(address)
+	if err != nil {
+		return fmt.Errorf("invalid remote Session %s: %v", address, err)
+	}
+
+	keys := s.remoteClientKeys[clientKey]
+	if keys == nil {
+		keys = map[int]bool{}
+		s.remoteClientKeys[clientKey] = keys
+	}
+	keys[sessionKey] = true
+
+	if PrintTunnelData {
+		logrus.Debugf("ADD REMOTE CLIENT %s, SESSION %d", address, s.sessionKey)
+	}
+
+	return nil
+}
+
+func (s *Session) removeRemoteClient(address string) error {
+	clientKey, sessionKey, err := parseAddress(address)
+	if err != nil {
+		return fmt.Errorf("invalid remote Session %s: %v", address, err)
+	}
+
+	keys := s.remoteClientKeys[clientKey]
+	delete(keys, int(sessionKey))
+	if len(keys) == 0 {
+		delete(s.remoteClientKeys, clientKey)
+	}
+
+	if PrintTunnelData {
+		logrus.Debugf("REMOVE REMOTE CLIENT %s, SESSION %d", address, s.sessionKey)
+	}
+
+	return nil
+}
+
+func (s *Session) closeConnection(connID int64, err error) {
+	s.Lock()
+	conn := s.conns[connID]
+	delete(s.conns, connID)
+	if PrintTunnelData {
+		logrus.Debugf("CONNECTIONS %d %d", s.sessionKey, len(s.conns))
+	}
+	s.Unlock()
+
+	if conn != nil {
+		conn.tunnelClose(err)
+	}
+}

--- a/session_serve.go
+++ b/session_serve.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// serveMessage accepts an incoming message from the underlying websocket connection and processes the request based on its messageType
 func (s *Session) serveMessage(ctx context.Context, reader io.Reader) error {
 	message, err := newServerMessage(reader)
 	if err != nil {
@@ -19,52 +20,31 @@ func (s *Session) serveMessage(ctx context.Context, reader io.Reader) error {
 		logrus.Debug("REQUEST ", message)
 	}
 
-	if message.messageType == Connect {
-		if s.auth == nil || !s.auth(message.proto, message.address) {
-			return errors.New("connect not allowed")
-		}
-		s.clientConnect(ctx, message)
-		return nil
-	}
-
-	s.Lock()
-	if message.messageType == AddClient && s.remoteClientKeys != nil {
-		err := s.addRemoteClient(message.address)
-		s.Unlock()
-		return err
-	} else if message.messageType == RemoveClient {
-		err := s.removeRemoteClient(message.address)
-		s.Unlock()
-		return err
-	}
-	conn := s.conns[message.connID]
-	s.Unlock()
-
-	if conn == nil {
-		if message.messageType == Data {
-			err := fmt.Errorf("connection not found %s/%d/%d", s.clientKey, s.sessionKey, message.connID)
-			newErrorMessage(message.connID, err).WriteTo(defaultDeadline(), s.conn)
-		}
-		return nil
-	}
-
 	switch message.messageType {
+	case Connect:
+		return s.clientConnect(ctx, message)
+	case AddClient:
+		return s.addRemoteClient(message.address)
+	case RemoveClient:
+		return s.removeRemoteClient(message.address)
 	case Data:
-		if err := conn.OnData(message); err != nil {
-			s.closeConnection(message.connID, err)
-		}
+		s.connectionData(message.connID, message.body)
 	case Pause:
-		conn.OnPause()
+		s.pauseConnection(message.connID)
 	case Resume:
-		conn.OnResume()
+		s.resumeConnection(message.connID)
 	case Error:
 		s.closeConnection(message.connID, message.Err())
 	}
-
 	return nil
 }
 
-func (s *Session) clientConnect(ctx context.Context, message *message) {
+// clientConnect accepts a new connection request, dialing back to establish the connection
+func (s *Session) clientConnect(ctx context.Context, message *message) error {
+	if s.auth == nil || !s.auth(message.proto, message.address) {
+		return errors.New("connect not allowed")
+	}
+
 	conn := newConnection(message.connID, s, message.proto, message.address)
 
 	s.Lock()
@@ -75,9 +55,19 @@ func (s *Session) clientConnect(ctx context.Context, message *message) {
 	s.Unlock()
 
 	go clientDial(ctx, s.dialer, conn, message)
+
+	return nil
 }
 
+// / addRemoteClient registers a new remote client, making it accessible for requests
 func (s *Session) addRemoteClient(address string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.remoteClientKeys == nil {
+		return nil
+	}
+
 	clientKey, sessionKey, err := parseAddress(address)
 	if err != nil {
 		return fmt.Errorf("invalid remote Session %s: %v", address, err)
@@ -97,14 +87,18 @@ func (s *Session) addRemoteClient(address string) error {
 	return nil
 }
 
+// / addRemoteClient removes a given client from a session
 func (s *Session) removeRemoteClient(address string) error {
+	s.Lock()
+	defer s.Unlock()
+
 	clientKey, sessionKey, err := parseAddress(address)
 	if err != nil {
 		return fmt.Errorf("invalid remote Session %s: %v", address, err)
 	}
 
 	keys := s.remoteClientKeys[clientKey]
-	delete(keys, int(sessionKey))
+	delete(keys, sessionKey)
 	if len(keys) == 0 {
 		delete(s.remoteClientKeys, clientKey)
 	}
@@ -116,6 +110,8 @@ func (s *Session) removeRemoteClient(address string) error {
 	return nil
 }
 
+// closeConnection removes a connection for a given ID from the session, sending an error message to communicate the closing to the other end.
+// If an error is not provided, io.EOF will be used instead.
 func (s *Session) closeConnection(connID int64, err error) {
 	s.Lock()
 	conn := s.conns[connID]
@@ -127,5 +123,33 @@ func (s *Session) closeConnection(connID int64, err error) {
 
 	if conn != nil {
 		conn.tunnelClose(err)
+	}
+}
+
+// connectionData process incoming data from connection by reading the body into an internal readBuffer
+func (s *Session) connectionData(connID int64, body io.Reader) {
+	conn := s.getConnection(connID)
+	if conn == nil {
+		errMsg := newErrorMessage(connID, fmt.Errorf("connection not found %s/%d/%d", s.clientKey, s.sessionKey, connID))
+		_, _ = errMsg.WriteTo(defaultDeadline(), s.conn)
+		return
+	}
+
+	if err := conn.OnData(body); err != nil {
+		s.closeConnection(connID, err)
+	}
+}
+
+// pauseConnection activates backPressure for a given connection ID
+func (s *Session) pauseConnection(connID int64) {
+	if conn := s.getConnection(connID); conn != nil {
+		conn.OnPause()
+	}
+}
+
+// resumeConnection deactivates backPressure for a given connection ID
+func (s *Session) resumeConnection(connID int64) {
+	if conn := s.getConnection(connID); conn != nil {
+		conn.OnResume()
 	}
 }

--- a/session_serve_test.go
+++ b/session_serve_test.go
@@ -1,0 +1,136 @@
+package remotedialer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSession_clientConnect(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	msgProto, msgAddr := "testproto", "testaddr"
+	s := setupDummySession(t, 0)
+	s.auth = func(proto, address string) bool { return proto == msgProto && address == msgAddr }
+
+	dialerC := make(chan struct{})
+	s.dialer = func(ctx context.Context, network, address string) (net.Conn, error) {
+		close(dialerC)
+		clientConn, _ := net.Pipe()
+		return clientConn, nil
+	}
+
+	connID := getDummyConnectionID()
+	if err := s.clientConnect(ctx, newConnect(connID, msgProto, msgAddr)); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-dialerC:
+	case <-time.After(1 * time.Second):
+		t.Errorf("timed out waiting for dialer")
+	}
+
+	if conn := s.getConnection(connID); conn == nil {
+		t.Errorf("Connection not found in session for ID %d", connID)
+	}
+}
+
+func TestSession_addRemoveRemoteClient(t *testing.T) {
+	s := setupDummySession(t, 0)
+	clientKey, sessionKey := "test", rand.Int()
+
+	msgAddress := fmt.Sprintf("%s/%d", clientKey, sessionKey)
+	if err := s.addRemoteClient(msgAddress); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := s.getSessionKeys(clientKey), map[int]bool{sessionKey: true}; !reflect.DeepEqual(got, want) {
+		t.Errorf("remote client session was not added correctly, got %v, want %v", got, want)
+	}
+
+	if err := s.removeRemoteClient(msgAddress); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := s.getSessionKeys(clientKey), 0; len(got) != want {
+		t.Errorf("remote client session was not removed correctly, got %v, want len(%d)", got, want)
+	}
+}
+
+func TestSession_connectionData(t *testing.T) {
+	s := setupDummySession(t, 0)
+	connID := getDummyConnectionID()
+	conn := newConnection(connID, s, "test", "test")
+	s.addConnection(connID, conn)
+
+	data := "testing!"
+	s.connectionData(connID, strings.NewReader(data))
+
+	if got, want := conn.buffer.offerCount, int64(len(data)); got != want {
+		t.Errorf("incorrect data length, got %d, want %d", got, want)
+	}
+
+	buf := make([]byte, conn.buffer.offerCount)
+	if _, err := conn.buffer.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(buf), data; got != want {
+		t.Errorf("incorrect data, got %q, want %q", got, want)
+	}
+}
+
+func TestSession_pauseResumeConnection(t *testing.T) {
+	s := setupDummySession(t, 0)
+	connID := getDummyConnectionID()
+	conn := newConnection(connID, s, "test", "test")
+	s.addConnection(connID, conn)
+
+	s.pauseConnection(connID)
+	if !conn.backPressure.paused {
+		t.Errorf("connection was not paused correctly")
+	}
+
+	s.resumeConnection(connID)
+	if conn.backPressure.paused {
+		t.Errorf("connection was not resumed correctly")
+	}
+}
+
+func TestSession_closeConnection(t *testing.T) {
+	s := setupDummySession(t, 0)
+	var msg *message
+	s.conn = &fakeWSConn{
+		writeMessageCallback: func(msgType int, _ time.Time, data []byte) (err error) {
+			msg, err = newServerMessage(bytes.NewReader(data))
+			return
+		},
+	}
+	connID := getDummyConnectionID()
+	conn := newConnection(connID, s, "test", "test")
+	s.addConnection(connID, conn)
+
+	expectedErr := errors.New("connection closed")
+	s.closeConnection(connID, expectedErr)
+
+	if s.getConnection(connID) != nil {
+		t.Errorf("connection was not closed correctly")
+	}
+	if conn.err == nil {
+		t.Fatal("message not sent on closed connection")
+	} else if msg.messageType != Error {
+		t.Errorf("incorrect message type sent")
+	} else if got, want := msg.Err().Error(), expectedErr.Error(); got != want {
+		t.Errorf("wrong error, got %v, want %v", got, want)
+	} else if got, want := conn.err, expectedErr; !errors.Is(got, want) {
+		t.Errorf("wrong error, got %v, want %v", got, want)
+	}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,77 @@
+package remotedialer
+
+import (
+	"math/rand"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+var dummyConnectionsNextID int64 = 1
+
+func getDummyConnectionID() int64 {
+	return atomic.AddInt64(&dummyConnectionsNextID, 1)
+}
+
+func setupDummySession(t *testing.T, nConnections int) *Session {
+	t.Helper()
+
+	s := newSession(rand.Int63(), "", nil)
+
+	var wg sync.WaitGroup
+	ready := make(chan struct{})
+	for i := 0; i < nConnections; i++ {
+		connID := getDummyConnectionID()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-ready
+			s.addConnection(connID, &connection{})
+		}()
+	}
+	close(ready)
+	wg.Wait()
+
+	if got, want := len(s.conns), nConnections; got != want {
+		t.Fatalf("incorrect number of connections, got: %d, want %d", got, want)
+	}
+
+	return s
+}
+
+func TestSession_connections(t *testing.T) {
+	const n = 10
+	s := setupDummySession(t, n)
+
+	connID, conn := getDummyConnectionID(), &connection{}
+	s.addConnection(connID, conn)
+	if got, want := len(s.conns), n+1; got != want {
+		t.Errorf("incorrect number of connections, got: %d, want %d", got, want)
+	}
+	if got, want := s.getConnection(connID), conn; got != want {
+		t.Errorf("incorrect result from getConnection, got: %v, want %v", got, want)
+	}
+	if got, want := s.removeConnection(connID), conn; got != want {
+		t.Errorf("incorrect result from removeConnection, got: %v, want %v", got, want)
+	}
+}
+
+func TestSession_sessionKeys(t *testing.T) {
+	s := setupDummySession(t, 0)
+
+	clientKey, sessionKey := "testkey", rand.Int()
+	s.addSessionKey(clientKey, sessionKey)
+	if got, want := len(s.remoteClientKeys), 1; got != want {
+		t.Errorf("incorrect number of remote client keys, got: %d, want %d", got, want)
+	}
+
+	if got, want := s.getSessionKeys(clientKey), map[int]bool{sessionKey: true}; !reflect.DeepEqual(got, want) {
+		t.Errorf("incorrect result from getSessionKeys, got: %v, want %v", got, want)
+	}
+
+	s.removeSessionKey(clientKey, sessionKey)
+	if got, want := len(s.remoteClientKeys), 0; got != want {
+		t.Errorf("incorrect number of remote client keys after removal, got: %d, want %d", got, want)
+	}
+}

--- a/wsconn_test.go
+++ b/wsconn_test.go
@@ -1,0 +1,30 @@
+package remotedialer
+
+import (
+	"errors"
+	"io"
+	"time"
+)
+
+type fakeWSConn struct {
+	writeMessageCallback func(int, time.Time, []byte) error
+}
+
+func (f fakeWSConn) Close() error {
+	return nil
+}
+
+func (f fakeWSConn) NextReader() (int, io.Reader, error) {
+	return 0, nil, errors.New("not implemented")
+}
+
+func (f fakeWSConn) WriteMessage(messageType int, deadline time.Time, data []byte) error {
+	if cb := f.writeMessageCallback; cb != nil {
+		return cb(messageType, deadline, data)
+	}
+	return errors.New("callback not provided")
+}
+
+func (f fakeWSConn) WriteControl(int, time.Time, []byte) error {
+	return errors.New("not implemented")
+}


### PR DESCRIPTION
## Issue: [44576](https://github.com/rancher/rancher/issues/44576)

Extracted a few modifications required in during the review of https://github.com/rancher/remotedialer/pull/74.

 - I've refactored `session.serveMessage` for the sake of simplicity. It now just parses the raw message and calls the appropriate method, and also moved relevant methods to an independent file.
 - Replaced the embedded `sync.Mutex` in `Session` with a `RWMutex`. Also, creating new methods to interact with the protected map, hence avoiding (most) of the callers to lock and unlock.
 - Abstracted `wsConn` into an interface, converting the existing `wsConn` into `wsWrapper`. This eases testing.