### PR TITLE
Allow passing a custom client-side dialer

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,8 +27,15 @@ func ClientConnect(ctx context.Context, wsURL string, headers http.Header, diale
 	return nil
 }
 
-// ConnectToProxy connect to websocket server
+// ConnectToProxy connects to the websocket server.
+// Local connections on behalf of the remote host will be dialed using a default net.Dialer.
 func ConnectToProxy(rootCtx context.Context, proxyURL string, headers http.Header, auth ConnectAuthorizer, dialer *websocket.Dialer, onConnect func(context.Context, *Session) error) error {
+	return ConnectToProxyWithDialer(rootCtx, proxyURL, headers, auth, dialer, nil, onConnect)
+}
+
+// ConnectToProxyWithDialer connects to the websocket server.
+// Local connections on behalf of the remote host will be dialed using the provided Dialer function.
+func ConnectToProxyWithDialer(rootCtx context.Context, proxyURL string, headers http.Header, auth ConnectAuthorizer, dialer *websocket.Dialer, localDialer Dialer, onConnect func(context.Context, *Session) error) error {
 	logrus.WithField("url", proxyURL).Info("Connecting to proxy")
 
 	if dialer == nil {
@@ -57,7 +64,7 @@ func ConnectToProxy(rootCtx context.Context, proxyURL string, headers http.Heade
 	ctx, cancel := context.WithCancel(rootCtx)
 	defer cancel()
 
-	session := NewClientSession(auth, ws)
+	session := NewClientSessionWithDialer(auth, ws, localDialer)
 	defer session.Close()
 
 	if onConnect != nil {


### PR DESCRIPTION
## Issue: 

* https://github.com/k3s-io/k3s/issues/10444

## Problem

Our remotedialer client needs to be able to provide a custom dialer for use when dialing connections on behalf of the server. Currently, the client dialer always uses an unconfigured `net.Dialer{}` struct, because there is no code path to call `NewClientSessionWithDialer`, meaning that `s.dialer` is always nil:
* https://github.com/rancher/remotedialer/blob/40afe79b0ceaf4dff88c2a77c6d98722b90d3b93/session_serve.go#L45-L56
* https://github.com/rancher/remotedialer/blob/40afe79b0ceaf4dff88c2a77c6d98722b90d3b93/client_dialer.go#L20-L25

## Solution

Add ConnectToProxyWithDialer that calls NewClientSessionWithDialer so that callers can provide a custom local dialer function.

There is no change to the existing ConnectoToProxy function signature or behavior, as the current code path also just calls `NewClientSessionWithDialer(auth, ws, nil)`

## CheckList
- [ ] Test
