### PR TITLE
Increase limitReader to 266 for accommodating larger hostnames

### DIFF
--- a/message.go
+++ b/message.go
@@ -162,7 +162,7 @@ func newServerMessage(reader io.Reader) (*message, error) {
 	}
 
 	if m.messageType == Connect {
-		bytes, err := ioutil.ReadAll(io.LimitReader(buf, 100))
+		bytes, err := ioutil.ReadAll(io.LimitReader(buf, 266))
 		if err != nil {
 			return nil, err
 		}

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,46 @@
+package remotedialer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestNewServerMessage_266(t *testing.T) {
+	var buf bytes.Buffer
+
+	writeVarint := func(n int64) {
+		b := make([]byte, binary.MaxVarintLen64)
+		written := binary.PutVarint(b, n)
+		buf.Write(b[:written])
+	}
+
+	writeVarint(1)
+	writeVarint(1)
+	writeVarint(int64(Connect))
+	writeVarint(0)
+
+	hostnameLen := 255
+	hostname := strings.Repeat("h", hostnameLen)
+	connectString := "tcp/" + hostname + ":65500"
+	buf.WriteString(connectString)
+
+	msg, err := newServerMessage(&buf)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if msg.id != 1 {
+		t.Errorf("Expected id 1, got: %d", msg.id)
+	}
+	if msg.connID != 1 {
+		t.Errorf("Expected connID 1, got: %d", msg.connID)
+	}
+	if msg.messageType != Connect {
+		t.Errorf("Expected messageType Connect (%d), got: %d", Connect, msg.messageType)
+	}
+	if string(msg.bytes) != connectString {
+		t.Errorf("Expected msg.bytes to equal connectString bytes, got: %v", string(msg.bytes))
+	}
+}


### PR DESCRIPTION
Issue  https://github.com/rancher/rancher/issues/43772

## Problem

The hostname of AKS private cluster is exceeding 100 char limit when a user uses a longer DNSPrefix while creating a cluster.

## Solution

Increase the limit to 266. 

We use the following format {protocol}/{hostname}:{port}. The max char limit for hostname is 255 char. 

255 (hostname) + 4 (protocol) + 1(/) + 1(:) + 5(port) = 266

## CheckList

- [x] Test
