### PR TITLE
Stop setting debug mode globally.

### DIFF
--- a/proxy/config.go
+++ b/proxy/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	ProxyPort       int    // tcp remotedialer-proxy port
 	PeerPort        int    // cluster-external service port
 	HTTPSPort       int    // https remotedialer-proxy port
+	Debug           bool
 }
 
 func requiredString(key string) (string, error) {
@@ -65,6 +66,7 @@ func ConfigFromEnvironment() (*Config, error) {
 	if config.HTTPSPort, err = requiredPort("HTTPS_PORT"); err != nil {
 		return nil, err
 	}
+	config.Debug = len(os.Getenv("DEBUG")) > 0
 
 	return &config, nil
 }

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -91,7 +91,9 @@ func pipe(a, b net.Conn) {
 }
 
 func Start(cfg *Config, restConfig *rest.Config) error {
-	logrus.SetLevel(logrus.DebugLevel)
+	if cfg.Debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 	ctx := context.Background()
 
 	// Setting Up Default Authorizer


### PR DESCRIPTION
It causes all of rancher to enter debug mode. So instead if there's a non-empty "DEBUG" environment variable we'll enter debug mode.

No associated issue.