### PR TITLE
Need a version of release/v0.4 without PR 90 remote-dialer proxy.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   "baseBranches": [
     "main",
     "release/v0.3"
+    "release/v0.4"
   ],
   "prHourlyLimit": 2,
   "packageRules": [

--- a/VERSION.md
+++ b/VERSION.md
@@ -2,8 +2,8 @@ RemoteDialer follows a pre-release (v0.x) strategy of semver. There is limited c
 
 The current supported release lines are:
 
-| RemoteDialer Branch | RemoteDialer Minor version | Matching Rancher Version |
+| RemoteDialer Branch | RemoteDialer Minor version
 |--------------------------|------------------------------------|
-| main | v0.5 | v2.12
-| release/v0.4 | v0.4 | v2.11.4+
-| release/v0.3 | v0.3 | v2.10, v2.11.0 - v2.11.3
+| main | v0.5
+| release/v0.4 | v0.4
+| release/v0.3 | v0.3

--- a/VERSION.md
+++ b/VERSION.md
@@ -2,7 +2,8 @@ RemoteDialer follows a pre-release (v0.x) strategy of semver. There is limited c
 
 The current supported release lines are:
 
-| RemoteDialer Branch | RemoteDialer Minor version | 
+| RemoteDialer Branch | RemoteDialer Minor version | Matching Rancher Version |
 |--------------------------|------------------------------------|
-| main | v0.4 |
-| release/v0.3 | v0.3 |
+| main | v0.5 | v2.12
+| release/v0.4 | v0.4 | v2.11.4+
+| release/v0.3 | v0.3 | v2.10, v2.11.0 - v2.11.3


### PR DESCRIPTION
The remotedialer proxy introduces dependencies on wrangler to remotedialer, and makes it harder to point
rancher v2.11 to new versions of remotedialer without bringing in all the recursive dependency bumps in 
wrangler and its dependencies.

This branch will pull the remoteproxy code out, as it isn't used in `rancher v2.11`