### PR TITLE
Remove mutex lock for stopPings

### DIFF
--- a/session.go
+++ b/session.go
@@ -311,11 +311,10 @@ func (s *Session) writeMessage(deadline time.Time, message *message) (int, error
 }
 
 func (s *Session) Close() {
-	s.Lock()
-	defer s.Unlock()
-
 	s.stopPings()
 
+	s.Lock()
+	defer s.Unlock()
 	for _, connection := range s.conns {
 		connection.tunnelClose(errors.New("tunnel disconnect"))
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

Issue : https://github.com/rancher/rancher/issues/51509

## Problem

As mentioned in the issue, stopPings has acquired the lock and it waits for startPings goroutine to complete, but that goroutine wants the same lock and keeps waiting until stopPings func finishes off therefore in a stalled situation i.e deadlock. 

## Solution

Upon understanding the codebase, I have realised that `startPings` function is only called once and the fields inside it `pingCancel` & `pingWait` have no mutexLocks. Taking the same analogy, inside the `stopPings` function, we don't need the mutex lock for `stopPings` functions. Also, everything inside `stopPings` function can be called safely by multiple goroutines.

Once we remove the mutex locks for `stopPings` function inside `close`, the deadlock doesn't occur since `stopPings` no longer acquires a mutex lock and so goroutine inside `startPings` can move on and finish itself.
