### PR TITLE
JIRA : SURE-10454

### DIFF
--- a/client.go
+++ b/client.go
@@ -82,6 +82,8 @@ func ConnectToProxyWithDialer(rootCtx context.Context, proxyURL string, headers 
 		result <- err
 	}()
 
+	logrus.WithField("url", proxyURL).Info("Connected to proxy")
+
 	select {
 	case <-ctx.Done():
 		logrus.WithField("url", proxyURL).WithField("err", ctx.Err()).Info("Proxy done")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

SURE-10454

## Problem

Working on the above issue, I have realised cattle cluster agents run on edge networks as part of the downstream clusters and often get dissconnected and connect back. There is no log message which says `connected` but there is log message which says `connecting`. 

## Solution

Add a log message which says `connected`.
