### PR TITLE
Allow registering with non-default Registerer

### DIFF
--- a/metrics/session_manager.go
+++ b/metrics/session_manager.go
@@ -101,20 +101,24 @@ var (
 // Register registers a series of session
 // metrics for Prometheus.
 func Register() {
+	MustRegister(prometheus.DefaultRegisterer)
+}
 
+// MustRegister registers all metrics with the provided registerer
+func MustRegister(registerer prometheus.Registerer) {
 	prometheusMetrics = true
 
 	// Session metrics
-	prometheus.MustRegister(TotalAddWS)
-	prometheus.MustRegister(TotalRemoveWS)
-	prometheus.MustRegister(TotalAddConnectionsForWS)
-	prometheus.MustRegister(TotalRemoveConnectionsForWS)
-	prometheus.MustRegister(TotalTransmitBytesOnWS)
-	prometheus.MustRegister(TotalTransmitErrorBytesOnWS)
-	prometheus.MustRegister(TotalReceiveBytesOnWS)
-	prometheus.MustRegister(TotalAddPeerAttempt)
-	prometheus.MustRegister(TotalPeerConnected)
-	prometheus.MustRegister(TotalPeerDisConnected)
+	registerer.MustRegister(TotalAddWS)
+	registerer.MustRegister(TotalRemoveWS)
+	registerer.MustRegister(TotalAddConnectionsForWS)
+	registerer.MustRegister(TotalRemoveConnectionsForWS)
+	registerer.MustRegister(TotalTransmitBytesOnWS)
+	registerer.MustRegister(TotalTransmitErrorBytesOnWS)
+	registerer.MustRegister(TotalReceiveBytesOnWS)
+	registerer.MustRegister(TotalAddPeerAttempt)
+	registerer.MustRegister(TotalPeerConnected)
+	registerer.MustRegister(TotalPeerDisConnected)
 }
 
 func init() {


### PR DESCRIPTION
## Issue: 

K3s uses custom metrics registerers/gatherers to avoid having metrics conflict when we embed everything in a single process. This is done in https://github.com/k3s-io/k3s/blob/master/pkg/metrics/metrics.go

In trying to expose remotedialer metrics, we discovered that the remotedialer metrics cannot be registered with any Registerer other than the default, which makes it difficult to expose them via the K3s metrics endpoint
* https://github.com/k3s-io/k3s/issues/12717


## Problem

Cannot register remotedialer metrics with a Prometheus Registerer other than the default, as it is hardcoded.

## Solution

Allow registering metrics with Registerers other than the default.
* Similar to: https://github.com/rancher/lasso/pull/89