### PR TITLE
Add sanity check to `Sync` packet handeling: to not remove connections the client didn't know about at time of packet construction

### DIFF
--- a/session.go
+++ b/session.go
@@ -91,15 +91,17 @@ func (s *Session) addConnection(connID int64, conn *connection) {
 
 	s.conns[connID] = conn
 
-	// only increment and only on client
-	if s.clientKey == "client" && s.nextConnID < connID {
-		s.nextConnID = connID
+	// Track the highest connection ID seen by the client, used for sync packet 'top' field.
+	// Only on client sessions - server sessions manage nextConnID via atomic.AddInt64 in serverConnect.
+	if s.client {
+		if old := atomic.LoadInt64(&s.nextConnID); old < connID {
+			atomic.StoreInt64(&s.nextConnID, connID)
+		}
 	}
 
 	if PrintTunnelData {
 		logrus.Debugf("CONNECTIONS %d %d", s.sessionKey, len(s.conns))
 	}
-
 }
 
 // removeConnection safely removes a connection by ID, returning the connection object
@@ -143,7 +145,7 @@ func (s *Session) activeConnectionIDs() ([]int64, int64) {
 		res = append(res, id)
 	}
 	sort.Slice(res, func(i, j int) bool { return res[i] < res[j] })
-	return res, s.nextConnID
+	return res, atomic.LoadInt64(&s.nextConnID)
 }
 
 // addSessionKey registers a new session key for a given client key

--- a/session.go
+++ b/session.go
@@ -90,9 +90,16 @@ func (s *Session) addConnection(connID int64, conn *connection) {
 	defer s.Unlock()
 
 	s.conns[connID] = conn
+
+	// only increment and only on client
+	if s.clientKey == "client" && s.nextConnID < connID {
+		s.nextConnID = connID
+	}
+
 	if PrintTunnelData {
 		logrus.Debugf("CONNECTIONS %d %d", s.sessionKey, len(s.conns))
 	}
+
 }
 
 // removeConnection safely removes a connection by ID, returning the connection object
@@ -111,6 +118,7 @@ func (s *Session) removeConnection(connID int64) *connection {
 // The session lock must be held by the caller when calling this method
 func (s *Session) removeConnectionLocked(connID int64) *connection {
 	conn := s.conns[connID]
+
 	delete(s.conns, connID)
 	return conn
 }
@@ -124,7 +132,9 @@ func (s *Session) getConnection(connID int64) *connection {
 }
 
 // activeConnectionIDs returns an ordered list of IDs for the currently active connections
-func (s *Session) activeConnectionIDs() []int64 {
+// it also returns s.nextConnID (a hack to have both the list of conns and nextConnID read in the same lock)
+// TODO: seperate latter functionality
+func (s *Session) activeConnectionIDs() ([]int64, int64) {
 	s.RLock()
 	defer s.RUnlock()
 
@@ -133,7 +143,7 @@ func (s *Session) activeConnectionIDs() []int64 {
 		res = append(res, id)
 	}
 	sort.Slice(res, func(i, j int) bool { return res[i] < res[j] })
-	return res
+	return res, s.nextConnID
 }
 
 // addSessionKey registers a new session key for a given client key
@@ -190,6 +200,7 @@ func (s *Session) startPings(rootCtx context.Context) {
 				if err := s.sendSyncConnections(); err != nil {
 					logrus.WithError(err).Error("Error syncing connections")
 				}
+
 			case <-t.C:
 				if err := s.sendPing(); err != nil {
 					logrus.WithError(err).Error("Error writing ping")

--- a/session_serve.go
+++ b/session_serve.go
@@ -95,12 +95,12 @@ func (s *Session) syncConnections(r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("reading message body: %w", err)
 	}
-	clientActiveConnections, err := decodeConnectionIDs(payload)
+	clientActiveConnections, top, err := decodeConnectionIDs(payload)
 	if err != nil {
 		return fmt.Errorf("decoding sync connections payload: %w", err)
 	}
 
-	s.compareAndCloseStaleConnections(clientActiveConnections)
+	s.compareAndCloseStaleConnections(clientActiveConnections, top)
 	return nil
 }
 

--- a/session_sync.go
+++ b/session_sync.go
@@ -9,45 +9,53 @@ import (
 
 var errCloseSyncConnections = errors.New("sync from client")
 
-// encodeConnectionIDs serializes a slice of connection IDs
-func encodeConnectionIDs(ids []int64) []byte {
-	payload := make([]byte, 0, 8*len(ids))
+// encodeConnectionIDs serializes a slice of connection IDs and the topmost connection ID seen
+func encodeConnectionIDs(top int64, ids []int64) []byte {
+	payload := make([]byte, 0, 8*(len(ids)+1))
+
+	// send top to denote the latest ID this packet was send with knowledge of
+	payload = binary.LittleEndian.AppendUint64(payload, uint64(top))
+
 	for _, id := range ids {
 		payload = binary.LittleEndian.AppendUint64(payload, uint64(id))
 	}
 	return payload
 }
 
-// decodeConnectionIDs deserializes a slice of connection IDs
-func decodeConnectionIDs(payload []byte) ([]int64, error) {
+// decodeConnectionIDs deserializes a slice of connection IDs along with the highest seen
+func decodeConnectionIDs(payload []byte) ([]int64, int64, error) {
 	if len(payload)%8 != 0 {
-		return nil, fmt.Errorf("incorrect data format")
+		return nil, 0, fmt.Errorf("incorrect data format")
 	}
-	result := make([]int64, 0, len(payload)/8)
-	for x := 0; x < len(payload); x += 8 {
+	top := int64(binary.LittleEndian.Uint64(payload[0 : 0+8]))
+
+	result := make([]int64, 0, (len(payload)/8)-1)
+	for x := 8; x < len(payload); x += 8 {
 		id := binary.LittleEndian.Uint64(payload[x : x+8])
 		result = append(result, int64(id))
 	}
-	return result, nil
+	return result, top, nil
 }
 
-func newSyncConnectionsMessage(connectionIDs []int64) *message {
+func newSyncConnectionsMessage(top int64, connectionIDs []int64) *message {
 	return &message{
 		id:          nextid(),
 		messageType: SyncConnections,
-		bytes:       encodeConnectionIDs(connectionIDs),
+		bytes:       encodeConnectionIDs(top, connectionIDs),
 	}
 }
 
 // sendSyncConnections sends a binary message of type SyncConnections, whose payload is a list of the active connection IDs for this session
 func (s *Session) sendSyncConnections() error {
-	_, err := s.writeMessage(time.Now().Add(SyncConnectionsTimeout), newSyncConnectionsMessage(s.activeConnectionIDs()))
+	act, top := s.activeConnectionIDs()
+
+	_, err := s.writeMessage(time.Now().Add(SyncConnectionsTimeout), newSyncConnectionsMessage(top, act))
 	return err
 }
 
 // compareAndCloseStaleConnections compares the Session's activeConnectionIDs with the provided list from the client, then closing every connection not present in it
-func (s *Session) compareAndCloseStaleConnections(clientIDs []int64) {
-	serverIDs := s.activeConnectionIDs()
+func (s *Session) compareAndCloseStaleConnections(clientIDs []int64, top int64) {
+	serverIDs, _ := s.activeConnectionIDs()
 	toClose := diffSortedSetsGetRemoved(serverIDs, clientIDs)
 	if len(toClose) == 0 {
 		return
@@ -55,9 +63,16 @@ func (s *Session) compareAndCloseStaleConnections(clientIDs []int64) {
 
 	s.Lock()
 	defer s.Unlock()
+
 	for _, id := range toClose {
+		// dont close connection if packet contains id not ever seen by client
+		if id > top {
+			break // not continue as toClose is sorted
+		}
+
 		// Connection no longer active in the client, close it server-side
 		conn := s.removeConnectionLocked(id)
+
 		if conn != nil {
 			// Using doTunnelClose directly instead of tunnelClose, omitting unnecessarily sending an Error message
 			conn.doTunnelClose(errCloseSyncConnections)

--- a/session_sync.go
+++ b/session_sync.go
@@ -9,6 +9,10 @@ import (
 
 var errCloseSyncConnections = errors.New("sync from client")
 
+// syncIgnoreTop disables the 'top' field guard in compareAndCloseStaleConnections.
+// Used only in tests to simulate the pre-fix behavior and verify the bug is reproducible.
+var syncIgnoreTop bool
+
 // encodeConnectionIDs serializes a slice of connection IDs and the topmost connection ID seen
 func encodeConnectionIDs(top int64, ids []int64) []byte {
 	payload := make([]byte, 0, 8*(len(ids)+1))
@@ -66,7 +70,7 @@ func (s *Session) compareAndCloseStaleConnections(clientIDs []int64, top int64) 
 
 	for _, id := range toClose {
 		// dont close connection if packet contains id not ever seen by client
-		if id > top {
+		if !syncIgnoreTop && id > top {
 			break // not continue as toClose is sorted
 		}
 

--- a/session_sync_test.go
+++ b/session_sync_test.go
@@ -31,12 +31,16 @@ func Test_encodeConnectionIDs(t *testing.T) {
 		tt := tests[x]
 		t.Run(fmt.Sprintf("%d_ids", tt.size), func(t *testing.T) {
 			t.Parallel()
-			ids := generateIDs(tt.size)
-			encoded := encodeConnectionIDs(ids)
-			decoded, err := decodeConnectionIDs(encoded)
+			ids, top := generateIDs(tt.size)
+			encoded := encodeConnectionIDs(top, ids)
+			decoded, decodedTop, err := decodeConnectionIDs(encoded)
 			if err != nil {
 				t.Error(err)
 			}
+			if got, want := decodedTop, top; !reflect.DeepEqual(got, want) {
+				t.Errorf("encoding and decoding differs from original data, got: %v, want: %v", got, want)
+			}
+
 			if got, want := decoded, ids; !reflect.DeepEqual(got, want) {
 				t.Errorf("encoding and decoding differs from original data, got: %v, want: %v", got, want)
 			}
@@ -93,7 +97,7 @@ func TestSession_sendSyncConnections(t *testing.T) {
 	session := newSession(rand.Int63(), "sync-test", newWSConn(conn))
 
 	for _, n := range []int{0, 5, 20} {
-		ids := generateIDs(n)
+		ids, _ := generateIDs(n)
 		for _, id := range ids {
 			session.conns[id] = nil
 		}
@@ -114,20 +118,28 @@ func TestSession_sendSyncConnections(t *testing.T) {
 		if got, want := message.messageType, SyncConnections; got != want {
 			t.Errorf("incorrect message type, got: %v, want: %v", got, want)
 		}
-		if decoded, err := decodeConnectionIDs(payload); err != nil {
+
+		decoded, decodedTop, err := decodeConnectionIDs(payload)
+		if err != nil {
 			t.Fatal(err)
-		} else if got, want := decoded, session.activeConnectionIDs(); !reflect.DeepEqual(got, want) {
+			return
+		}
+		returnedIDs, returnedTop := session.activeConnectionIDs()
+		if got, want := decodedTop, returnedTop; !reflect.DeepEqual(got, want) {
+			t.Errorf("incorrect connections IDs, got: %v, want: %v", got, want)
+		}
+		if got, want := decoded, returnedIDs; !reflect.DeepEqual(got, want) {
 			t.Errorf("incorrect connections IDs, got: %v, want: %v", got, want)
 		}
 	}
 }
 
-func generateIDs(n int) []int64 {
+func generateIDs(n int) ([]int64, int64) {
 	ids := make([]int64, n)
 	for x := range ids {
 		ids[x] = rand.Int63()
 	}
-	return ids
+	return ids, rand.Int63()
 }
 
 func testServerWS(t *testing.T, data chan<- []byte) *websocket.Conn {

--- a/session_sync_test.go
+++ b/session_sync_test.go
@@ -6,11 +6,16 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -267,4 +272,154 @@ func TestCompareAndCloseStaleConnections(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSyncConnectionsRace is an integration test that reproduces the race condition
+// described in PR #150. When SyncConnectionsInterval is very small and many concurrent
+// requests are being processed, the sync mechanism can close connections that the client
+// hasn't yet received. The fix adds a 'top' field to sync packets so the server knows
+// not to close connections with IDs the client hasn't seen yet.
+//
+// The test runs two subtests:
+//   - without_fix: disables the 'top' guard via syncIgnoreTop, proving the bug exists
+//     (sync error rate > 10%)
+//   - with_fix: runs with the 'top' guard enabled, proving the fix works
+//     (sync error rate < 10%)
+//
+// Note: With the 'top' field fix, connections the client hasn't seen are protected.
+// However, there is a separate (pre-existing) timing window where the client completes
+// and removes a connection before the server does. In those cases the sync correctly
+// closes the stale server-side connection, but this can briefly interrupt in-flight
+// HTTP responses on the server side. The 'top' field does not address this case.
+func TestSyncConnectionsRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	origInterval := SyncConnectionsInterval
+	origTimeout := SyncConnectionsTimeout
+	origIgnoreTop := syncIgnoreTop
+
+	// Aggressive sync settings to maximize the race window
+	SyncConnectionsInterval = time.Millisecond
+	SyncConnectionsTimeout = time.Second
+
+	t.Cleanup(func() {
+		SyncConnectionsInterval = origInterval
+		SyncConnectionsTimeout = origTimeout
+		syncIgnoreTop = origIgnoreTop
+	})
+
+	const totalRequests = 500
+	const maxErrorPercent = 10
+	threshold := int64(totalRequests * maxErrorPercent / 100) // 50
+
+	t.Run("without_fix", func(t *testing.T) {
+		syncIgnoreTop = true
+		_, syncErrs := runSyncRaceLoad(t, totalRequests)
+
+		// Without the 'top' guard, the error rate should be high (typically >10%),
+		// proving the bug is reproducible.
+		if syncErrs <= threshold {
+			t.Errorf("expected sync error rate >%d%% without fix, but got only %d/%d sync errors",
+				maxErrorPercent, syncErrs, totalRequests)
+		}
+	})
+
+	t.Run("with_fix", func(t *testing.T) {
+		syncIgnoreTop = false
+		_, syncErrs := runSyncRaceLoad(t, totalRequests)
+
+		// With the 'top' guard, the error rate should be significantly lower (<10%).
+		// A small number of errors are expected from the pre-existing race where the
+		// client removes a completed connection before the server does.
+		if syncErrs > threshold {
+			t.Errorf("sync error rate too high with fix: got %d/%d sync errors (max allowed: %d)",
+				syncErrs, totalRequests, threshold)
+		}
+	})
+}
+
+// runSyncRaceLoad sets up a remotedialer tunnel and fires totalRequests concurrent HTTP
+// requests through it, returning the total error count and sync-specific error count.
+// SyncConnectionsInterval and SyncConnectionsTimeout must be set by the caller.
+func runSyncRaceLoad(t *testing.T, totalRequests int) (totalErrors, syncErrors int64) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Backend HTTP server that returns a response body.
+	responseBody := strings.Repeat("x", 4096)
+	backendAddr, err := newServer(ctx, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(responseBody))
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// remotedialer server
+	serverAddr, server, err := newTestServer(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Connect client
+	if err := newTestClient(ctx, "ws://"+serverAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	// HTTP client that routes through the remotedialer tunnel
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+				return server.Dialer("client")(ctx, network, address)
+			},
+			DisableKeepAlives: true,
+		},
+	}
+
+	const concurrency = 50
+
+	sem := make(chan struct{}, concurrency)
+	var (
+		wg           sync.WaitGroup
+		errCount     int64
+		syncErrCount int64
+	)
+
+	for i := 0; i < totalRequests; i++ {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer func() {
+				<-sem
+				wg.Done()
+			}()
+
+			resp, err := client.Get("http://" + backendAddr)
+			if err != nil {
+				atomic.AddInt64(&errCount, 1)
+				if strings.Contains(err.Error(), errCloseSyncConnections.Error()) {
+					atomic.AddInt64(&syncErrCount, 1)
+				}
+				return
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}()
+	}
+
+	wg.Wait()
+
+	// Stop all goroutines before returning
+	cancel()
+	time.Sleep(200 * time.Millisecond)
+
+	t.Logf("completed %d requests: %d total errors, %d sync errors",
+		totalRequests, errCount, syncErrCount)
+
+	return errCount, syncErrCount
 }

--- a/session_sync_test.go
+++ b/session_sync_test.go
@@ -175,3 +175,96 @@ func testServerWS(t *testing.T, data chan<- []byte) *websocket.Conn {
 	t.Cleanup(func() { _ = conn.Close() })
 	return conn
 }
+
+// TestCompareAndCloseStaleConnections tests that compareAndCloseStaleConnections
+// correctly handles the 'top' field: connections with IDs greater than top should
+// never be closed (the client hasn't seen them yet), while stale connections with
+// IDs <= top should be closed.
+func TestCompareAndCloseStaleConnections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		serverConns    []int64
+		clientConns    []int64
+		top            int64
+		expectedOpen   []int64
+		expectedClosed []int64
+	}{
+		{
+			name:           "no connections to close when lists match",
+			serverConns:    []int64{1, 2, 3},
+			clientConns:    []int64{1, 2, 3},
+			top:            3,
+			expectedOpen:   []int64{1, 2, 3},
+			expectedClosed: nil,
+		},
+		{
+			name:           "close stale connections at or below top",
+			serverConns:    []int64{1, 2, 3, 4, 5},
+			clientConns:    []int64{1, 3, 5},
+			top:            5,
+			expectedOpen:   []int64{1, 3, 5},
+			expectedClosed: []int64{2, 4},
+		},
+		{
+			name:           "preserve all connections above top",
+			serverConns:    []int64{1, 2, 3, 4, 5},
+			clientConns:    []int64{1, 2, 3},
+			top:            3,
+			expectedOpen:   []int64{1, 2, 3, 4, 5},
+			expectedClosed: nil,
+		},
+		{
+			name:           "mixed: close old stale and preserve new unknown",
+			serverConns:    []int64{1, 2, 3, 4, 5, 10, 20},
+			clientConns:    []int64{1, 3},
+			top:            5,
+			expectedOpen:   []int64{1, 3, 10, 20},
+			expectedClosed: []int64{2, 4, 5},
+		},
+		{
+			name:           "empty client list with low top preserves everything",
+			serverConns:    []int64{5, 10, 15},
+			clientConns:    []int64{},
+			top:            0,
+			expectedOpen:   []int64{5, 10, 15},
+			expectedClosed: nil,
+		},
+		{
+			name:           "empty client list with high top closes all",
+			serverConns:    []int64{1, 2, 3},
+			clientConns:    []int64{},
+			top:            10,
+			expectedOpen:   nil,
+			expectedClosed: []int64{1, 2, 3},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := setupDummySession(t, 0)
+			for _, id := range tt.serverConns {
+				conn := newConnection(id, s, "test", "test")
+				s.addConnection(id, conn)
+			}
+
+			s.compareAndCloseStaleConnections(tt.clientConns, tt.top)
+
+			for _, id := range tt.expectedOpen {
+				if s.getConnection(id) == nil {
+					t.Errorf("connection %d should be open but was closed", id)
+				}
+			}
+
+			for _, id := range tt.expectedClosed {
+				if s.getConnection(id) != nil {
+					t.Errorf("connection %d should be closed but is still open", id)
+				}
+			}
+		})
+	}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -116,7 +116,9 @@ func TestSession_activeConnectionIDs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			session := Session{conns: tt.conns}
-			if got, want := session.activeConnectionIDs(), tt.expected; !reflect.DeepEqual(got, want) {
+
+			returnedIDs, _ := session.activeConnectionIDs()
+			if got, want := returnedIDs, tt.expected; !reflect.DeepEqual(got, want) {
 				t.Errorf("incorrect result, got: %v, want: %v", got, want)
 			}
 		})

--- a/types.go
+++ b/types.go
@@ -5,12 +5,15 @@ import "time"
 const (
 	PingWaitDuration  = 60 * time.Second
 	PingWriteInterval = 5 * time.Second
+	MaxRead           = 8192
+	HandshakeTimeOut  = 10 * time.Second
+	// SendErrorTimeout sets the maximum duration for sending an error message to close a single connection
+	SendErrorTimeout = 5 * time.Second
+)
+
+var (
 	// SyncConnectionsInterval is the time after which the client will send the list of active connection IDs
 	SyncConnectionsInterval = 60 * time.Second
 	// SyncConnectionsTimeout sets the maximum duration for a SyncConnections operation
 	SyncConnectionsTimeout = 60 * time.Second
-	MaxRead                = 8192
-	HandshakeTimeOut       = 10 * time.Second
-	// SendErrorTimeout sets the maximum duration for sending an error message to close a single connection
-	SendErrorTimeout = 5 * time.Second
 )


### PR DESCRIPTION
## Issue:  https://github.com/rancher/rancher/issues/54512 

## Problem

In case of multiple concurrent requests being processed remotedialer sometimes returns a `sync from client` error to an api client.

How to reproduce:
1. clone repo
2. edit `types.go` and reduce `﻿SyncConnectionsInterval` and `SyncConnectionsTimeout` to `time.Second / 60` or similar
3. edit `remotedialer/dummyserver` to not return any http body (commenting out line `24`)
4. execute `dummy` `server` and `client` examples
5. send obscene amounts of http requests through remotedialer (parallelism is important here)
```
set c 1000; while true;
  set res "$(for i in (seq 1 $c);
    curl -0 "http://localhost:8123/client/foo/http/localhost:8125" -s -o - 2>/dev/zero& end; wait)";
    echo "'$res' $(echo -n "$res" | wc -c)";
  if [ -z "$res" ]; echo "no errors"; else date; break; end;
  sleep 2
end
```

sometimes this works just fine, while other times a lot of `Get "http://localhost:8125": sync from client` messages get returned by remotedialer.

This is not the case if one sets `SyncConnections{Interval,Timeout}` to very large numbers (= removing sync all together)- doing so fixes the error without leaving stale connections.

Part of the problem (the part i address in this PR) was the implementation of the sync process.
Is was implemented in a way in which the client sends the server a list of all connection IDs the client still has open and the server closes the ones it has the client doesn't. This enabled the possibility of the client not yet knowing about a new connection, sending a `Sync` packet and the server then removing this connection before it had a chance of reaching the client.

## Solution

To resolve this specific case, I've added a additional field to the `Sync` Packet. It sends the highest (and therefore latest) connection the client has received at time of crafting the packet. The server then only closes connections that are closed on the client AND older than the clients knowledge at time of crafting the packet.

This **DOES NOT** completely eliminate the issue at hand though it greatly decreased the chance of it occurring.

I am convinced the rest of the issue is caused by the server sending connections out of order, i.e. `connectionIDs` not being linear when received or processed by the client, though I have not been able to come up with anything.

## CheckList

- [ ] Test
