### PR TITLE
[release/v0.5] Adopt hardened-build-base for proxy builder image

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder
+FROM rancher/hardened-build-base:v1.26.4b1@sha256:82b0ded3f892de5eacc070500456c8002f544083a91648b55233822fbd64ff6a AS builder
 WORKDIR /app
 
 COPY . .


### PR DESCRIPTION
## Summary
- Replace `golang:1.24` with `rancher/hardened-build-base:v1.26.4b1` (pinned by digest) as the proxy builder image
