### PR TITLE
Fix data race on connection.err

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/rancher/remotedialer/metrics"
@@ -11,6 +12,7 @@ import (
 )
 
 type connection struct {
+	errMu         sync.Mutex
 	err           error
 	writeDeadline time.Time
 	backPressure  *backPressure
@@ -41,17 +43,27 @@ func (c *connection) tunnelClose(err error) {
 }
 
 func (c *connection) doTunnelClose(err error) {
+	c.errMu.Lock()
 	if c.err != nil {
+		c.errMu.Unlock()
 		return
 	}
 
-	metrics.IncSMTotalRemoveConnectionsForWS(c.session.clientKey, c.addr.Network(), c.addr.String())
-	c.err = err
-	if c.err == nil {
-		c.err = io.ErrClosedPipe
+	if err == nil {
+		err = io.ErrClosedPipe
 	}
+	c.err = err
+	c.errMu.Unlock()
 
-	c.buffer.Close(c.err)
+	metrics.IncSMTotalRemoveConnectionsForWS(c.session.clientKey, c.addr.Network(), c.addr.String())
+	c.buffer.Close(err)
+}
+
+// getErr returns the error the connection was closed with, or nil if it is still open.
+func (c *connection) getErr() error {
+	c.errMu.Lock()
+	defer c.errMu.Unlock()
+	return c.err
 }
 
 func (c *connection) OnData(r io.Reader) error {
@@ -79,7 +91,7 @@ func (c *connection) Read(b []byte) (int, error) {
 }
 
 func (c *connection) Write(b []byte) (int, error) {
-	if c.err != nil {
+	if c.getErr() != nil {
 		return 0, io.ErrClosedPipe
 	}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,36 @@
+package remotedialer
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// TestConnection_TunnelCloseRace exercises concurrent access to connection.err:
+// doTunnelClose can be reached simultaneously from Session.Close,
+// Session.closeConnection and the client pipe, while Write checks err from the
+// data path. Run with -race to detect regressions.
+func TestConnection_TunnelCloseRace(t *testing.T) {
+	s := setupDummySession(t, 0)
+	s.conn = &fakeWSConn{}
+
+	conn := newConnection(getDummyConnectionID(), s, "test", "test")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			conn.doTunnelClose(errors.New("tunnel disconnect"))
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = conn.Write([]byte("data"))
+		}()
+	}
+	wg.Wait()
+
+	if conn.getErr() == nil {
+		t.Fatal("expected connection to be closed with an error")
+	}
+}


### PR DESCRIPTION
## Issue: 

Fixes https://github.com/rancher/remotedialer/issues/254

## Problem

`connection.err` is accessed without synchronization. `doTunnelClose` does an unguarded check-then-set of `c.err`, and it can be reached concurrently for the same connection from `Session.Close`, `Session.closeConnection` (via `serveMessage`), `session_sync`, and the client pipe (`clientDial`/`pipe`). Meanwhile `connection.Write` reads `c.err` from the data path with no synchronization.

`go test -race` flags this whenever a session is torn down while connections are active — see the two full race detector traces in #254. Beyond the detector noise (which makes `-race` unusable for any project embedding remotedialer), two concurrent closers can both pass the `c.err != nil` guard, double-counting the `IncSMTotalRemoveConnectionsForWS` metric and calling `buffer.Close` twice with different errors, and `Write` can observe a stale value.

## Solution

Guard `err` with a `sync.Mutex`:

- `doTunnelClose` performs its check-and-set under the lock (only the first closer proceeds; the metrics increment and `buffer.Close` still happen exactly once, outside the lock).
- `Write` reads through a new locked getter, `getErr()`.

Behavior is otherwise unchanged: same error precedence (`io.ErrClosedPipe` when closed with nil), same single `buffer.Close(err)` call.

## CheckList

- [x] Test

Added `TestConnection_TunnelCloseRace`, which hammers `doTunnelClose` and `Write` concurrently on one connection. Under `go test -race` it fails on current `main` and passes with this change. The full suite passes with `-race -count=3`. Also verified in the downstream project where we originally hit this: its integration tests fail under `-race` on every run against v0.6.1 and pass with this patch applied via a `replace` directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
