### PR TITLE
fix: fix possible race in connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ server:
 	go build -o server/server ./server
 
 test:
-	go test -cover ./...
+	go test -cover ./... -race
 
 .PHONY: all client dummy server test

--- a/connection.go
+++ b/connection.go
@@ -2,8 +2,10 @@ package remotedialer
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/rancher/remotedialer/metrics"
@@ -11,6 +13,7 @@ import (
 )
 
 type connection struct {
+	lock          sync.RWMutex
 	err           error
 	writeDeadline time.Time
 	backPressure  *backPressure
@@ -41,17 +44,30 @@ func (c *connection) tunnelClose(err error) {
 }
 
 func (c *connection) doTunnelClose(err error) {
-	if c.err != nil {
+	err, didSet := c.setErrIfNotSet(err)
+	if !didSet {
 		return
 	}
 
 	metrics.IncSMTotalRemoveConnectionsForWS(c.session.clientKey, c.addr.Network(), c.addr.String())
-	c.err = err
-	if c.err == nil {
-		c.err = io.ErrClosedPipe
+	c.buffer.Close(err)
+}
+
+// setErrIfNotSet sets the error if it is not already set.
+// Returns true if the error was set, false if it was already set.
+// Regardless, the error is returned.
+func (c *connection) setErrIfNotSet(err error) (error, bool) {
+	if err == nil {
+		err = io.ErrClosedPipe
 	}
 
-	c.buffer.Close(c.err)
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.err == nil {
+		c.err = err
+		return c.err, true
+	}
+	return c.err, false
 }
 
 func (c *connection) OnData(r io.Reader) error {
@@ -79,19 +95,22 @@ func (c *connection) Read(b []byte) (int, error) {
 }
 
 func (c *connection) Write(b []byte) (int, error) {
-	if c.err != nil {
-		return 0, io.ErrClosedPipe
+	c.lock.RLock()
+	err := c.err
+	writeDeadline := c.writeDeadline
+	c.lock.RUnlock()
+
+	if err != nil {
+		return 0, errors.Join(err, io.ErrClosedPipe)
 	}
+
 	ctx, cancel := context.WithCancel(context.Background())
-	if !c.writeDeadline.IsZero() {
-		ctx, cancel = context.WithDeadline(ctx, c.writeDeadline)
+	if !writeDeadline.IsZero() {
+		ctx, cancel = context.WithDeadline(ctx, writeDeadline)
 		go func(ctx context.Context) {
-			select {
-			case <-ctx.Done():
-				if ctx.Err() == context.DeadlineExceeded {
-					c.Close()
-				}
-				return
+			<-ctx.Done()
+			if ctx.Err() == context.DeadlineExceeded {
+				c.Close()
 			}
 		}(ctx)
 	}
@@ -99,7 +118,7 @@ func (c *connection) Write(b []byte) (int, error) {
 	c.backPressure.Wait(cancel)
 	msg := newMessage(c.connID, b)
 	metrics.AddSMTotalTransmitBytesOnWS(c.session.clientKey, float64(len(msg.Bytes())))
-	return c.session.writeMessage(c.writeDeadline, msg)
+	return c.session.writeMessage(writeDeadline, msg)
 }
 
 func (c *connection) OnPause() {
@@ -112,12 +131,12 @@ func (c *connection) OnResume() {
 
 func (c *connection) Pause() {
 	msg := newPause(c.connID)
-	_, _ = c.session.writeMessage(c.writeDeadline, msg)
+	_, _ = c.session.writeMessage(c.getWriteDeadline(), msg)
 }
 
 func (c *connection) Resume() {
 	msg := newResume(c.connID)
-	_, _ = c.session.writeMessage(c.writeDeadline, msg)
+	_, _ = c.session.writeMessage(c.getWriteDeadline(), msg)
 }
 
 func (c *connection) writeErr(err error) {
@@ -152,8 +171,16 @@ func (c *connection) SetReadDeadline(t time.Time) error {
 }
 
 func (c *connection) SetWriteDeadline(t time.Time) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.writeDeadline = t
 	return nil
+}
+
+func (c *connection) getWriteDeadline() time.Time {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.writeDeadline
 }
 
 type addr struct {

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,49 @@
+package remotedialer
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestConnectionSetWriteDeadlineConcurrentWrite(t *testing.T) {
+	t.Parallel()
+
+	s := setupDummySession(t, 0)
+	s.conn = &fakeWSConn{
+		writeMessageCallback: func(int, time.Time, []byte) error {
+			return nil
+		},
+	}
+	conn := newConnection(getDummyConnectionID(), s, "test", "test")
+
+	const iterations = 1000
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			if _, err := conn.Write([]byte("test")); err != nil {
+				t.Errorf("Write() error = %v", err)
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			if err := conn.SetWriteDeadline(time.Time{}); err != nil {
+				t.Errorf("SetWriteDeadline() error = %v", err)
+				return
+			}
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+}


### PR DESCRIPTION
Go's race detector triggers on reading the connection's error and write deadline. This change introduces a mutex to avoid this race. Tests are added that would fail when run with -race without the changes here.

Additionally, one simplification is made to remove an unneeded select statement.