### PR TITLE
fix: fix possible race in connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ server:
 	go build -o server/server ./server
 
 test:
-	go test -cover ./...
+	go test -cover ./... -race
 
 .PHONY: all client dummy server test

--- a/connection.go
+++ b/connection.go
@@ -2,8 +2,10 @@ package remotedialer
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/rancher/remotedialer/metrics"
@@ -12,7 +14,9 @@ import (
 
 type connection struct {
 	err           error
+	errMu         sync.Mutex
 	writeDeadline time.Time
+	deadlineMu    sync.Mutex
 	backPressure  *backPressure
 	buffer        *readBuffer
 	addr          addr
@@ -41,17 +45,20 @@ func (c *connection) tunnelClose(err error) {
 }
 
 func (c *connection) doTunnelClose(err error) {
+	c.errMu.Lock()
+	defer c.errMu.Unlock()
+
 	if c.err != nil {
 		return
 	}
 
 	metrics.IncSMTotalRemoveConnectionsForWS(c.session.clientKey, c.addr.Network(), c.addr.String())
-	c.err = err
-	if c.err == nil {
-		c.err = io.ErrClosedPipe
+	if err == nil {
+		err = io.ErrClosedPipe
 	}
 
-	c.buffer.Close(c.err)
+	c.buffer.Close(err)
+	c.err = err
 }
 
 func (c *connection) OnData(r io.Reader) error {
@@ -79,19 +86,20 @@ func (c *connection) Read(b []byte) (int, error) {
 }
 
 func (c *connection) Write(b []byte) (int, error) {
-	if c.err != nil {
-		return 0, io.ErrClosedPipe
+	if err := c.Err(); err != nil {
+		if !errors.Is(err, io.ErrClosedPipe) {
+			err = errors.Join(io.ErrClosedPipe, err)
+		}
+		return 0, err
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	if !c.writeDeadline.IsZero() {
-		ctx, cancel = context.WithDeadline(ctx, c.writeDeadline)
+	writeDeadline := c.GetWriteDeadline()
+	if !writeDeadline.IsZero() {
+		ctx, cancel = context.WithDeadline(ctx, writeDeadline)
 		go func(ctx context.Context) {
-			select {
-			case <-ctx.Done():
-				if ctx.Err() == context.DeadlineExceeded {
-					c.Close()
-				}
-				return
+			<-ctx.Done()
+			if ctx.Err() == context.DeadlineExceeded {
+				c.Close()
 			}
 		}(ctx)
 	}
@@ -99,7 +107,7 @@ func (c *connection) Write(b []byte) (int, error) {
 	c.backPressure.Wait(cancel)
 	msg := newMessage(c.connID, b)
 	metrics.AddSMTotalTransmitBytesOnWS(c.session.clientKey, float64(len(msg.Bytes())))
-	return c.session.writeMessage(c.writeDeadline, msg)
+	return c.session.writeMessage(writeDeadline, msg)
 }
 
 func (c *connection) OnPause() {
@@ -152,8 +160,22 @@ func (c *connection) SetReadDeadline(t time.Time) error {
 }
 
 func (c *connection) SetWriteDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	defer c.deadlineMu.Unlock()
 	c.writeDeadline = t
 	return nil
+}
+
+func (c *connection) GetWriteDeadline() time.Time {
+	c.deadlineMu.Lock()
+	defer c.deadlineMu.Unlock()
+	return c.writeDeadline
+}
+
+func (c *connection) Err() error {
+	c.errMu.Lock()
+	defer c.errMu.Unlock()
+	return c.err
 }
 
 type addr struct {

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,49 @@
+package remotedialer
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestConnectionSetWriteDeadlineConcurrentWrite(t *testing.T) {
+	t.Parallel()
+
+	s := setupDummySession(t, 0)
+	s.conn = &fakeWSConn{
+		writeMessageCallback: func(int, time.Time, []byte) error {
+			return nil
+		},
+	}
+	conn := newConnection(getDummyConnectionID(), s, "test", "test")
+
+	const iterations = 1000
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			if _, err := conn.Write([]byte("test")); err != nil {
+				t.Errorf("Write() error = %v", err)
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			if err := conn.SetWriteDeadline(time.Time{}); err != nil {
+				t.Errorf("SetWriteDeadline() error = %v", err)
+				return
+			}
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+}


### PR DESCRIPTION
* Alt version of https://github.com/rancher/remotedialer/pull/259 - credit to @thedadams for initial implementation

## Issue: n/a

## Problem

Go's race detector triggers on reading the connection's error and write deadline. 

## Solution

This change introduces mutexes to avoid races reading err and deadline. Tests are added that would fail when run with -race without the changes here.

Additionally, one simplification is made to remove an unneeded select statement.

## CheckList
- [X] Test - yes, added `-race` to existing test execution
