### PR TITLE
Fix data races on Session.pingCancel and connection.err; run the suite with -race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ server:
 	go build -o server/server ./server
 
 test:
-	go test -cover ./...
+	go test -race -cover ./...
 
 .PHONY: all client dummy server test

--- a/connection.go
+++ b/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/rancher/remotedialer/metrics"
@@ -11,6 +12,11 @@ import (
 )
 
 type connection struct {
+	// errMu guards err. tunnelClose arrives from several goroutines at once —
+	// a pipe copy noticing its peer failed, Session.Close tearing down every
+	// connection, serveMessage on a protocol error — and doTunnelClose's
+	// check-then-set of err was a data race between any two of them.
+	errMu         sync.Mutex
 	err           error
 	writeDeadline time.Time
 	backPressure  *backPressure
@@ -41,17 +47,21 @@ func (c *connection) tunnelClose(err error) {
 }
 
 func (c *connection) doTunnelClose(err error) {
+	// First closer wins; the lock is released before buffer.Close so no lock
+	// is held while calling into the buffer's own synchronization.
+	c.errMu.Lock()
 	if c.err != nil {
+		c.errMu.Unlock()
 		return
 	}
+	if err == nil {
+		err = io.ErrClosedPipe
+	}
+	c.err = err
+	c.errMu.Unlock()
 
 	metrics.IncSMTotalRemoveConnectionsForWS(c.session.clientKey, c.addr.Network(), c.addr.String())
-	c.err = err
-	if c.err == nil {
-		c.err = io.ErrClosedPipe
-	}
-
-	c.buffer.Close(c.err)
+	c.buffer.Close(err)
 }
 
 func (c *connection) OnData(r io.Reader) error {
@@ -79,7 +89,10 @@ func (c *connection) Read(b []byte) (int, error) {
 }
 
 func (c *connection) Write(b []byte) (int, error) {
-	if c.err != nil {
+	c.errMu.Lock()
+	failed := c.err != nil
+	c.errMu.Unlock()
+	if failed {
 		return 0, io.ErrClosedPipe
 	}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/session.go
+++ b/session.go
@@ -170,7 +170,12 @@ func (s *Session) getSessionKeys(clientKey string) map[int]bool {
 
 func (s *Session) startPings(rootCtx context.Context) {
 	ctx, cancel := context.WithCancel(rootCtx)
+	// Written under the session lock: Serve (which calls this) runs on its own
+	// goroutine while Close reads the field via stopPings — see ConnectToProxy,
+	// which composes exactly that pair.
+	s.Lock()
 	s.pingCancel = cancel
+	s.Unlock()
 	s.pingWait.Add(1)
 
 	go func() {
@@ -210,11 +215,19 @@ func (s *Session) sendPing() error {
 }
 
 func (s *Session) stopPings() {
-	if s.pingCancel == nil {
+	// Take the cancel func under the lock, then release before cancelling:
+	// pingWait.Wait() must not run while holding a lock the ping goroutine's
+	// callees (getSessionKeys, sendSyncConnections) also take. Nil-ing the
+	// field makes a second Close a no-op instead of a second cancel.
+	s.Lock()
+	cancel := s.pingCancel
+	s.pingCancel = nil
+	s.Unlock()
+	if cancel == nil {
 		return
 	}
 
-	s.pingCancel()
+	cancel()
 	s.pingWait.Wait()
 }
 

--- a/session.go
+++ b/session.go
@@ -172,11 +172,14 @@ func (s *Session) startPings(rootCtx context.Context) {
 	ctx, cancel := context.WithCancel(rootCtx)
 	// Written under the session lock: Serve (which calls this) runs on its own
 	// goroutine while Close reads the field via stopPings — see ConnectToProxy,
-	// which composes exactly that pair.
+	// which composes exactly that pair. The Add must sit inside the same
+	// critical section: stopPings pairs its Wait with observing a non-nil
+	// pingCancel, so the Add has to happen-before that observation or the
+	// two race on the WaitGroup.
 	s.Lock()
 	s.pingCancel = cancel
-	s.Unlock()
 	s.pingWait.Add(1)
+	s.Unlock()
 
 	go func() {
 		defer s.pingWait.Done()

--- a/session_close_race_test.go
+++ b/session_close_race_test.go
@@ -1,0 +1,80 @@
+package remotedialer
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingWSConn is the least conn that lets Serve run: NextReader blocks
+// until the conn is closed, so the read loop parks exactly the way it does on
+// a healthy websocket with no traffic.
+type blockingWSConn struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (c *blockingWSConn) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return nil
+}
+
+func (c *blockingWSConn) NextReader() (int, io.Reader, error) {
+	<-c.closed
+	return 0, nil, io.EOF
+}
+
+func (c *blockingWSConn) WriteControl(int, time.Time, []byte) error { return nil }
+func (c *blockingWSConn) WriteMessage(int, time.Time, []byte) error { return nil }
+
+// TestSessionCloseDoesNotRaceServeStartup pins a data race between
+// Session.Serve and Session.Close on s.pingCancel.
+//
+// The concurrency here is not invented by the test: it is the shape
+// ConnectToProxyWithDialer itself creates —
+//
+//	go func() { session.Serve(ctx) }()   // Serve → startPings: s.pingCancel = cancel
+//	defer session.Close()                // Close → stopPings:  if s.pingCancel == nil
+//
+// When the caller's context is cancelled just after connecting, the deferred
+// Close runs concurrently with Serve's startup and the two touch s.pingCancel
+// with no synchronization, even though Session carries a sync.RWMutex that
+// every neighbouring field already uses.
+//
+// In production the two are separated by the lifetime of a session, which is
+// why this survived: the window only closes to nothing when sessions are
+// opened and torn down rapidly — a reconnect storm, or a test suite driving
+// real tunnels. It was found by `go test -race` doing exactly that.
+//
+// The loop gives the detector repeated chances at the window; a single
+// iteration can park the two goroutines apart by chance. 200 iterations
+// trips it reliably while staying well under a second of wall time.
+func TestSessionCloseDoesNotRaceServeStartup(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		conn := &blockingWSConn{closed: make(chan struct{})}
+		s := newSession(int64(i), "race-probe", conn)
+		// What NewClientSession sets: only the client side sends pings, so
+		// only the client side runs startPings.
+		s.client = true
+
+		ctx, cancel := context.WithCancel(context.Background())
+		served := make(chan struct{})
+		go func() {
+			defer close(served)
+			_, _ = s.Serve(ctx)
+		}()
+
+		// The deferred Close from ConnectToProxyWithDialer, arriving while
+		// Serve is still starting up.
+		s.Close()
+
+		// Unwind: release the read loop, stop the ping goroutine if it did
+		// start, and wait for both so iterations cannot bleed into each other.
+		_ = conn.Close()
+		cancel()
+		<-served
+		s.pingWait.Wait()
+	}
+}


### PR DESCRIPTION
Two data races, both in goroutine pairs this library itself creates. Neither is visible to CI today because `make test` does not use `-race`; this PR turns it on, and the first commit is deliberately the failing half so the detector's report against unfixed code is on the record in CI history.

## Race 1: `Session.pingCancel`

`ConnectToProxyWithDialer` composes the racing pair itself:

```go
go func() { session.Serve(ctx) }()   // Serve → startPings: s.pingCancel = cancel   (write, no lock)
defer session.Close()                // Close → stopPings:  if s.pingCancel == nil  (read, no lock)
```

A client whose context is cancelled shortly after connecting has `Close` running concurrently with `Serve`'s startup. `Session` already embeds `sync.RWMutex` — neighbouring fields use it; `pingCancel` was never put under it.

The fix takes the lock on both sides. `stopPings` grabs the cancel func under the lock and **releases before cancelling**, so `pingWait.Wait()` is never awaited while holding a lock the ping goroutine's callees (`getSessionKeys` via `sendSyncConnections`) also take. Nil-ing the field under the lock makes a second `Close` a no-op.

Found downstream by a test suite that opens and tears down real tunnels rapidly under `go test -race`. Report: read at `session.go:213` (`stopPings` ← `Close`), previous write at `session.go:173` (`startPings` ← `Serve`).

## Race 2: `connection.err`

`doTunnelClose` does an unguarded check-then-set of `c.err`, and is reachable concurrently from a pipe copy noticing its peer failed (`client_dialer.go`), from `Session.Close` tearing down every connection, and from `serveMessage` on a protocol error. **This repo's own `TestExceedBuffer` trips it** once `-race` is on — the CI run for the first commit of this PR shows it.

`connection` had no synchronization at all; the fix adds an `errMu` guarding `err`. First closer wins; the lock is released before `buffer.Close` so it is never held while calling into the buffer's own synchronization; `Write`'s early-exit read moves under the same lock.

## Test

`TestSessionCloseDoesNotRaceServeStartup` drives `Serve` and `Close` the same way `ConnectToProxyWithDialer` does, in a loop so the detector gets repeated chances at the startup window. It fails on the first commit of this PR and passes on the second, both in this PR's own CI history.

`-race` roughly doubles the suite's runtime (it stays under a couple of minutes) — happy to move it to a separate make target if you'd rather keep `make test` lean.
