### PR TITLE
Add client disconnect API

### DIFF
--- a/server.go
+++ b/server.go
@@ -83,6 +83,10 @@ func (s *Server) ListClients() []string {
 	return s.sessions.listClients()
 }
 
+func (s *Server) Disconnect(clientKey string) {
+	s.sessions.disconnect(clientKey)
+}
+
 func (s *Server) auth(req *http.Request) (clientKey string, authed, peer bool, err error) {
 	id := req.Header.Get(ID)
 	token := req.Header.Get(Token)

--- a/session_manager.go
+++ b/session_manager.go
@@ -77,6 +77,16 @@ func (sm *sessionManager) listClients() []string {
 	return clients
 }
 
+func (sm *sessionManager) disconnect(clientKey string) {
+	sm.Lock()
+	sessions := append([]*Session(nil), sm.clients[clientKey]...)
+	sm.Unlock()
+
+	for _, session := range sessions {
+		session.conn.Close()
+	}
+}
+
 func (sm *sessionManager) getDialer(clientKey string) (Dialer, error) {
 	sm.Lock()
 	defer sm.Unlock()


### PR DESCRIPTION
## Problem

Remotedialer does not provide a public API for actively disconnecting a client. Consumers that need to force a client to reconnect must track and close the underlying connection themselves.

## Solution

Add `Server.Disconnect(clientKey)` to close the active WebSocket connections associated with a client.

The existing `ServeHTTP` cleanup path handles removing the sessions and closing related tunnel connections.