### PR TITLE
Add configurable connection backoff (SURE-8745)

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,71 @@
+package remotedialer
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+)
+
+// DefaultRetryMin is the delay used when Backoff.Min is unset.
+const DefaultRetryMin = 5 * time.Second
+
+// jitterPercent spreads delays so clients do not reconnect in lockstep.
+const jitterPercent = 10
+
+// Backoff controls how long a client waits between connection attempts.
+type Backoff struct {
+	// Min is the first retry delay. Zero means DefaultRetryMin.
+	Min time.Duration
+
+	// Max caps the delay; unset keeps it fixed at Min.
+	Max time.Duration
+}
+
+// delay returns the jittered wait before the given retry.
+func (b Backoff) delay(attempt int) time.Duration {
+	d := b.Min
+	if d <= 0 {
+		d = DefaultRetryMin
+	}
+
+	if b.Max > d {
+		for i := 0; i < attempt && d < b.Max; i++ {
+			// Saturate instead of doubling past Max, which would overflow.
+			if d > b.Max/2 {
+				d = b.Max
+				break
+			}
+			d *= 2
+		}
+	}
+
+	return jitter(d)
+}
+
+// jitter randomises d by plus or minus jitterPercent.
+func jitter(d time.Duration) time.Duration {
+	// Divide before multiplying so a huge d cannot overflow.
+	delta := int64(d) / 100 * jitterPercent
+	if delta <= 0 {
+		return d
+	}
+
+	j := d - time.Duration(delta) + time.Duration(rand.Int64N(2*delta+1))
+	if j < 0 {
+		return d
+	}
+	return j
+}
+
+// sleep waits for d or until ctx is done.
+func sleep(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,98 @@
+package remotedialer
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+)
+
+// assertJittered checks got is want give or take jitterPercent.
+func assertJittered(t *testing.T, got, want time.Duration) {
+	t.Helper()
+
+	delta := time.Duration(int64(want) / 100 * jitterPercent)
+	if got < want-delta || got > want+delta {
+		t.Errorf("delay = %s, want %s +/-%s", got, want, delta)
+	}
+}
+
+func TestBackoffDelay(t *testing.T) {
+	exponential := Backoff{Min: 5 * time.Second, Max: 5 * time.Minute}
+
+	tests := []struct {
+		name    string
+		backoff Backoff
+		attempt int
+		want    time.Duration
+	}{
+		{"zero value uses the default", Backoff{}, 0, DefaultRetryMin},
+		{"zero value never grows", Backoff{}, 100, DefaultRetryMin},
+		{"negative Min falls back to the default", Backoff{Min: -time.Second}, 3, DefaultRetryMin},
+		{"negative attempt yields Min", exponential, -1, 5 * time.Second},
+
+		{"Min alone never grows", Backoff{Min: 30 * time.Second}, 7, 30 * time.Second},
+		{"negative Max never grows", Backoff{Min: 5 * time.Second, Max: -time.Second}, 3, 5 * time.Second},
+		{"Max equal to Min never grows", Backoff{Min: time.Minute, Max: time.Minute}, 4, time.Minute},
+		{"Max below Min never grows", Backoff{Min: time.Minute, Max: time.Second}, 5, time.Minute},
+
+		{"first retry waits Min", exponential, 0, 5 * time.Second},
+		{"second retry doubles", exponential, 1, 10 * time.Second},
+		{"third retry doubles", exponential, 2, 20 * time.Second},
+		{"fourth retry doubles", exponential, 3, 40 * time.Second},
+		{"fifth retry doubles", exponential, 4, 80 * time.Second},
+		{"sixth retry doubles", exponential, 5, 160 * time.Second},
+		{"seventh retry saturates at Max", exponential, 6, 5 * time.Minute},
+		{"later retries stay at Max", exponential, 100, 5 * time.Minute},
+
+		{"saturates rather than overshooting Max", Backoff{Min: 5 * time.Second, Max: 6 * time.Second}, 1, 6 * time.Second},
+		{"lands exactly on Max", Backoff{Min: 5 * time.Second, Max: 10 * time.Second}, 1, 10 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertJittered(t, tt.backoff.delay(tt.attempt), tt.want)
+		})
+	}
+}
+
+// A non-positive delay would busy-loop the caller, so guard the extremes.
+func TestBackoffDelayAlwaysPositive(t *testing.T) {
+	maxes := []time.Duration{
+		time.Duration(math.MaxInt64),
+		time.Duration(math.MaxInt64) / 2,
+		292 * 365 * 24 * time.Hour,
+		100 * 365 * 24 * time.Hour,
+	}
+
+	for _, max := range maxes {
+		b := Backoff{Min: 5 * time.Second, Max: max}
+		for attempt := range 80 {
+			if got := b.delay(attempt); got <= 0 {
+				t.Fatalf("Backoff{Max: %v}.delay(%d) = %v, want a positive duration", max, attempt, got)
+			}
+		}
+	}
+}
+
+// Jitter must vary delays or clients reconnect in lockstep.
+func TestBackoffDelayJitterVaries(t *testing.T) {
+	b := Backoff{Min: 5 * time.Second}
+
+	seen := map[time.Duration]bool{}
+	for range 100 {
+		seen[b.delay(0)] = true
+	}
+
+	if len(seen) < 2 {
+		t.Errorf("got %d distinct delay(s) over 100 calls, want jitter to vary them", len(seen))
+	}
+}
+
+// ClientConnect needs context.Canceled visible through the wrapper.
+func TestDialErrorUnwraps(t *testing.T) {
+	if !errors.Is(error(dialError{context.Canceled}), context.Canceled) {
+		t.Error("errors.Is(dialError{context.Canceled}, context.Canceled) = false, want true")
+	}
+}

--- a/client.go
+++ b/client.go
@@ -15,6 +15,18 @@ import (
 // ConnectAuthorizer custom for authorization
 type ConnectAuthorizer func(proto, address string) bool
 
+// ConnectOpts holds optional settings for a client connection.
+type ConnectOpts struct {
+	// Backoff controls the wait between attempts. Zero means fixed DefaultRetryMin.
+	Backoff Backoff
+}
+
+// dialError marks a failed handshake rather than a dropped tunnel.
+type dialError struct{ error }
+
+// Unwrap keeps errors.Is and errors.As working through the wrapper.
+func (e dialError) Unwrap() error { return e.error }
+
 // ClientConnect connect to WS and wait 5 seconds when error
 func ClientConnect(ctx context.Context, wsURL string, headers http.Header, dialer *websocket.Dialer,
 	auth ConnectAuthorizer, onConnect func(context.Context, *Session) error) error {
@@ -26,6 +38,34 @@ func ClientConnect(ctx context.Context, wsURL string, headers http.Header, diale
 		return err
 	}
 	return nil
+}
+
+// ClientConnectWithOpts reconnects until ctx is cancelled, backing off between attempts.
+func ClientConnectWithOpts(ctx context.Context, wsURL string, headers http.Header, dialer *websocket.Dialer,
+	auth ConnectAuthorizer, onConnect func(context.Context, *Session) error, opts *ConnectOpts) error {
+	var backoff Backoff
+	if opts != nil {
+		backoff = opts.Backoff
+	}
+
+	for attempt := 0; ; attempt++ {
+		err := ConnectToProxy(ctx, wsURL, headers, auth, dialer, onConnect)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// A non-dial error means the tunnel was up.
+		var de dialError
+		if !errors.As(err, &de) {
+			attempt = 0
+		}
+
+		d := backoff.delay(attempt)
+		logrus.WithError(err).Errorf("Remotedialer proxy error, reconnecting to %s in %s", wsURL, d)
+		if err := sleep(ctx, d); err != nil {
+			return err
+		}
+	}
 }
 
 // ConnectToProxy connects to the websocket server.
@@ -56,7 +96,7 @@ func ConnectToProxyWithDialer(rootCtx context.Context, proxyURL string, headers 
 				logrus.WithError(err).Errorf("Failed to connect to proxy. Response status: %v - %v. Response body: %s", resp.StatusCode, resp.Status, rb)
 			}
 		}
-		return err
+		return dialError{err}
 	}
 	defer ws.Close()
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,49 @@
+package remotedialer
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A failed handshake must be retried, and cancellation must end the loop.
+func TestClientConnectWithOptsRetriesUntilCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	attempts := 0
+
+	// Refusing the upgrade makes every attempt fail its handshake.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attempts++
+		reached := attempts
+		mu.Unlock()
+
+		if reached == 3 {
+			cancel()
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	err := ClientConnectWithOpts(ctx, wsURL, nil, nil, nil, nil,
+		&ConnectOpts{Backoff: Backoff{Min: time.Millisecond}})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("ClientConnectWithOpts() = %v, want context.Canceled", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts < 3 {
+		t.Errorf("server saw %d attempt(s), want at least 3", attempts)
+	}
+}


### PR DESCRIPTION
- Reconnect delay was a hardcoded 5s sleep; a 2h outage burns ~720 doomed attempts.
- Adds `Backoff{Min, Max}`: Min alone stays fixed, Max enables doubling up to that ceiling.
- Delays carry ±10% jitter, so fleets no longer reconnect in lockstep after an outage.
- `ClientConnectWithOpts` owns the retry loop and resets once a tunnel connects.
- `ClientConnect` is untouched and the zero `Backoff` is fixed 5s, so consumers are unaffected.

Refs: SURE-8745, rancher/rancher#56746